### PR TITLE
[Bug] Detect Reddit share/short URLs and show user-friendly error

### DIFF
--- a/feedbackflow.tests/UrlParsingTests.cs
+++ b/feedbackflow.tests/UrlParsingTests.cs
@@ -83,4 +83,58 @@ public class UrlParsingTests
         Assert.IsNull(UrlParsing.ExtractVideoId(""));
         Assert.IsNull(UrlParsing.ExtractVideoId(null!));
     }
+
+    [TestMethod]
+    public void ExtractRedditId_ValidThreadUrl_ReturnsId()
+    {
+        var result = UrlParsing.ExtractRedditId("https://www.reddit.com/r/dotnet/comments/abc123/some-title/");
+        Assert.AreEqual("abc123", result);
+    }
+
+    [TestMethod]
+    public void ExtractRedditId_DirectId_ReturnsId()
+    {
+        var result = UrlParsing.ExtractRedditId("abc123");
+        Assert.AreEqual("abc123", result);
+    }
+
+    [TestMethod]
+    public void ExtractRedditId_T3Prefix_ReturnsId()
+    {
+        var result = UrlParsing.ExtractRedditId("t3_abc123");
+        Assert.AreEqual("abc123", result);
+    }
+
+    [TestMethod]
+    public void ExtractRedditId_ShareUrl_ReturnsNull()
+    {
+        var result = UrlParsing.ExtractRedditId("https://www.reddit.com/r/dotnet/s/nInjTaac2X");
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void ExtractRedditId_ShareUrlWithHttp_ReturnsNull()
+    {
+        var result = UrlParsing.ExtractRedditId("http://www.reddit.com/r/csharp/s/abcDEF1234");
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void IsRedditShareUrl_ValidShareUrl_ReturnsTrue()
+    {
+        Assert.IsTrue(UrlParsing.IsRedditShareUrl("https://www.reddit.com/r/dotnet/s/nInjTaac2X"));
+    }
+
+    [TestMethod]
+    public void IsRedditShareUrl_RegularThreadUrl_ReturnsFalse()
+    {
+        Assert.IsFalse(UrlParsing.IsRedditShareUrl("https://www.reddit.com/r/dotnet/comments/abc123/some-title/"));
+    }
+
+    [TestMethod]
+    public void IsRedditShareUrl_NullOrEmpty_ReturnsFalse()
+    {
+        Assert.IsFalse(UrlParsing.IsRedditShareUrl(""));
+        Assert.IsFalse(UrlParsing.IsRedditShareUrl(null!));
+    }
 }

--- a/feedbackwebapp/Services/Feedback/RedditFeedbackService.cs
+++ b/feedbackwebapp/Services/Feedback/RedditFeedbackService.cs
@@ -30,6 +30,13 @@ public class RedditFeedbackService : FeedbackService, IRedditFeedbackService
 
     public override async Task<(string rawComments, int commentCount, object? additionalData)> GetComments()
     {
+        if (UrlParsing.IsRedditShareUrl(_threadId))
+        {
+            throw new InvalidOperationException(
+                "Reddit share links (e.g. reddit.com/r/.../s/...) are not supported. " +
+                "Please use the full Reddit thread URL instead (e.g. reddit.com/r/.../comments/...).");
+        }
+
         var processedId = UrlParsing.ExtractRedditId(_threadId);
 
         if (string.IsNullOrWhiteSpace(processedId))

--- a/shareddump/Utils/UrlParsing.cs
+++ b/shareddump/Utils/UrlParsing.cs
@@ -82,11 +82,22 @@ public static class UrlParsing
             
         if (IsValidRedditId(url))
             return url;
-            
+
+        // Reddit share/short URLs (e.g. reddit.com/r/subreddit/s/code) are not supported
+        // Return null so callers can detect and show a specific error via IsRedditShareUrl
         if (RedditUrlParser.IsRedditShortUrl(url))
-            return url;
+            return null;
 
         return null;
+    }
+
+    /// <summary>
+    /// Checks if the URL is a Reddit share/short URL (e.g. https://www.reddit.com/r/dotnet/s/nInjTaac2X).
+    /// These URLs cannot be resolved to thread IDs and are not supported.
+    /// </summary>
+    public static bool IsRedditShareUrl(string url)
+    {
+        return !string.IsNullOrWhiteSpace(url) && RedditUrlParser.IsRedditShortUrl(url);
     }
 
     private static bool TryParseRedditUrl(string url, out string threadId)


### PR DESCRIPTION
## Why

Reddit share links (e.g. `https://www.reddit.com/r/dotnet/s/nInjTaac2X`) use an opaque short code that requires an HTTP redirect to resolve into a real thread URL. This resolution is unreliable — when it fails, the app silently produces no results with no explanation to the user.

## Approach

Instead of attempting to resolve share URLs, detect them early in the validation pipeline and show a clear, actionable error message asking the user to paste the full thread URL.

- **`UrlParsing.ExtractRedditId`** — now returns `null` for share URLs (previously returned the raw URL, which downstream couldn't use)
- **`UrlParsing.IsRedditShareUrl`** — new helper to explicitly check for the `/r/.../s/...` pattern
- **`RedditFeedbackService.GetComments`** — checks for share URLs before general validation and throws a specific error: *"Reddit share links are not supported. Please use the full Reddit thread URL instead."*
- **Tests** — 6 new tests covering share URL rejection, detection, and edge cases

## Notes

- The existing `RedditUrlParser.IsRedditShortUrl` regex and the Azure Function shortlink resolution code are left in place for now — they could be cleaned up in a follow-up if desired.
- Build verified ✅ (tests couldn't execute locally due to .NET 9 runtime not being available in the dev environment).