### PR TITLE
Migrate solution baseline to .NET 10

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,9 +36,9 @@ The github repo is jamesmontemagno/feedbackflow and the primary branch that I wo
 ## Architecture Overview
 
 ### Tech Stack
-- **.NET 9** with C# latest features, file-scoped namespaces
+- **.NET 10** with C# latest features, file-scoped namespaces
 - **Blazor Server** for interactive web UI with real-time updates
-- **Azure Functions** (.NET 9) for serverless backend APIs
+- **Azure Functions** (.NET 10) for serverless backend APIs
 - **.NET Aspire** for local orchestration and service discovery
 - **Bootstrap** + custom CSS variables for responsive theming
 
@@ -292,13 +292,13 @@ See AdminReports.razor and AdminApiKeyManagement.razor for reference implementat
 - **Local settings**: Create `feedbackfunctions/local.settings.json` with required API keys
 - **Storage emulator**: Uses `AzureWebJobsStorage: "UseDevelopmentStorage=true"` for local development  
 - **Required API keys**: GitHub PAT, YouTube API key, Azure OpenAI endpoint/key, Reddit credentials
-- **Functions runtime**: `dotnet-isolated` (.NET 9)
+- **Functions runtime**: `dotnet-isolated` (.NET 10)
 - **Key endpoints**: SaveSharedAnalysis, GetSharedAnalysis, GitHubIssuesReport, WeeklyReportProcessor
 
 ### Package Management
 - Uses **Central Package Management** via `Directory.Packages.props`
 - Key packages: Azure.AI.OpenAI, Azure.Data.Tables, Microsoft.Azure.Functions.Worker, Blazor.SpeechSynthesis
-- All projects target **.NET 9** with nullable reference types enabled
+- All projects target **.NET 10** with nullable reference types enabled
 
 ## Domain Architecture & Data Flow
 

--- a/.github/workflows/build-publish-mcp.yml
+++ b/.github/workflows/build-publish-mcp.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build FeedbackFlow.MCP.Local
         run: dotnet build FeedbackFlow.MCP.Local/FeedbackFlow.MCP.Local.csproj
@@ -36,7 +36,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Install dependencies
       run: dotnet restore FeedbackFlow.slnx

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
   
       - name: Install dependencies
         run: dotnet restore FeedbackFlow.slnx

--- a/.github/workflows/deploy-functions-staging.yml
+++ b/.github/workflows/deploy-functions-staging.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './feedbackfunctions'
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   build:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build with dotnet
         run: dotnet build "${{env.WEB_APP_PATH}}" --configuration Release

--- a/.github/workflows/main_feedbackfunctions20250414121421.yml
+++ b/.github/workflows/main_feedbackfunctions20250414121421.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './feedbackfunctions' # set this to the path to your web app project, defaults to the repository root
-  DOTNET_VERSION: '9.0.x' # set this to the dotnet version to use
+  DOTNET_VERSION: '10.0.x' # set this to the dotnet version to use
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/main_feedbackwebapp20250414225345.yml
+++ b/.github/workflows/main_feedbackwebapp20250414225345.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
 
       - name: Build with dotnet
         run: dotnet build "${{env.WEB_APP_PATH}}" --configuration Release

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "azureFunctions.deploySubpath": "feedbackfunctions/bin/Release/net9.0/publish",
+    "azureFunctions.deploySubpath": "feedbackfunctions/bin/Release/net10.0/publish",
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
 			"type": "func",
 			"dependsOn": "build (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/feedbackfunctions/bin/Debug/net9.0"
+				"cwd": "${workspaceFolder}/feedbackfunctions/bin/Debug/net10.0"
 			},
 			"command": "host start",
 			"isBackground": true,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,11 +31,11 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25502.107" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25502.107" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,11 +31,11 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.2.25502.107" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,12 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="9.5.2-preview.1.25522.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.5.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Blazor.SpeechSynthesis" Version="9.0.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
@@ -24,23 +23,23 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.2-preview.1.25552.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.10.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="MSTest" Version="4.0.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
@@ -49,6 +48,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 </Project>

--- a/FeedbackFlow.AppHost/AppHost.csproj
+++ b/FeedbackFlow.AppHost/AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.Functions" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
   </ItemGroup>

--- a/FeedbackFlow.AppHost/AppHost.csproj
+++ b/FeedbackFlow.AppHost/AppHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>c19c975b-3cc8-449a-934d-72ed74a1cc7a</UserSecretsId>

--- a/FeedbackFlow.MCP.Local/FeedbackFlow.MCP.Local.csproj
+++ b/FeedbackFlow.MCP.Local/FeedbackFlow.MCP.Local.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>FeedbackFlow.MCP.Local</RootNamespace>

--- a/FeedbackFlow.MCP.Remote/FeedbackFlow.MCP.Remote.csproj
+++ b/FeedbackFlow.MCP.Remote/FeedbackFlow.MCP.Remote.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>FeedbackFlow.MCP.Remote</RootNamespace>

--- a/FeedbackFlow.MCP.Shared/FeedbackFlow.MCP.Shared.csproj
+++ b/FeedbackFlow.MCP.Shared/FeedbackFlow.MCP.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>FeedbackFlow.MCP.Shared</RootNamespace>

--- a/FeedbackFlow.ServiceDefaults/ServiceDefaults.csproj
+++ b/FeedbackFlow.ServiceDefaults/ServiceDefaults.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Comprehensive test suite using MSTest for:
 
 To use FeedbackFlow, ensure you have the following:
 
-- .NET 9.0 SDK installed
+- .NET 10.0 SDK installed
 - A valid GitHub API Key
 - A valid YouTube API Key
 

--- a/docs/mcp-feedbackflow-server.md
+++ b/docs/mcp-feedbackflow-server.md
@@ -330,7 +330,7 @@ dotnet run --project FeedbackFlow.MCP.Remote/FeedbackFlow.MCP.Remote.csproj
 | Detail | Value |
 |--------|-------|
 | Image | `jamesmontemagno/feedbackflowmcp:latest` |
-| Base | .NET 9 runtime (console) |
+| Base | .NET 10 runtime (console) |
 | Version Tags | `latest` (rolling) – use a digest or future version tag for pinning |
 | Protocol | MCP (JSON-RPC over stdio) |
 

--- a/feedbackflow.tests/Tests.csproj
+++ b/feedbackflow.tests/Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/feedbackfunctions/Functions.csproj
+++ b/feedbackfunctions/Functions.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/feedbackwebapp/WebApp.csproj
+++ b/feedbackwebapp/WebApp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>FeedbackWebApp</RootNamespace>

--- a/shareddump/Shared.csproj
+++ b/shareddump/Shared.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>SharedDump</RootNamespace>


### PR DESCRIPTION
## Summary
- migrate solution projects and local tooling paths from .NET 9 to .NET 10
- replace temporary RC Microsoft.Extensions abstractions package pins with stable 10.0.5
- update GitHub Actions workflows to use .NET 10 SDK versions

## Validation
- dotnet build FeedbackFlow.slnx --configuration Release
- dotnet test FeedbackFlow.slnx --configuration Release

Closes #233