### PR TITLE
Add baseline backend performance instrumentation

### DIFF
--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
@@ -544,16 +545,19 @@ public class FeedbackFunctions
         [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req)
     {
         _logger.LogInformation("Processing comment analysis request");
+        var stopwatch = Stopwatch.StartNew();
 
         // Authenticate the request
         var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
         if (authErrorResponse != null)
             return authErrorResponse;
+        var authElapsedMs = stopwatch.ElapsedMilliseconds;
 
         // Validate usage limits
         var usageValidationResponse = await req.ValidateUsageAsync(user!, UsageType.Analysis, _userAccountService, _logger);
         if (usageValidationResponse != null)
             return usageValidationResponse;
+        var usageValidationElapsedMs = stopwatch.ElapsedMilliseconds;
 
         try
         {
@@ -580,6 +584,7 @@ public class FeedbackFunctions
                     promptToUse = SharedDump.AI.FeedbackAnalyzerService.GetPromptByType(parsedPromptType);
                 }
             }
+            var parseElapsedMs = stopwatch.ElapsedMilliseconds;
 
             var analysisBuilder = new System.Text.StringBuilder();
             await foreach (var update in _analyzerService.GetStreamingAnalysisAsync(
@@ -589,18 +594,31 @@ public class FeedbackFunctions
             {
                 analysisBuilder.Append(update);
             }
+            var analysisElapsedMs = stopwatch.ElapsedMilliseconds;
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             await response.WriteStringAsync(analysisBuilder.ToString());
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
             
             // Track usage on successful completion
             await user!.TrackUsageAsync(UsageType.Analysis, _userAccountService, _logger, request.ServiceType);
+
+            _logger.LogInformation(
+                "AnalyzeComments performance: totalMs={TotalMs}, authMs={AuthMs}, usageValidationMs={UsageValidationMs}, parseMs={ParseMs}, analysisMs={AnalysisMs}, responseWriteMs={ResponseWriteMs}, commentsLength={CommentsLength}, serviceType={ServiceType}",
+                stopwatch.ElapsedMilliseconds,
+                authElapsedMs,
+                usageValidationElapsedMs - authElapsedMs,
+                parseElapsedMs - usageValidationElapsedMs,
+                analysisElapsedMs - parseElapsedMs,
+                responseWriteElapsedMs - analysisElapsedMs,
+                request.Comments.Length,
+                request.ServiceType);
             
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing comment analysis request");
+            _logger.LogError(ex, "Error processing comment analysis request after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
             var response = req.CreateResponse(HttpStatusCode.InternalServerError);
             await response.WriteStringAsync("An error occurred processing the request");
             return response;

--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -549,14 +549,20 @@ public class FeedbackFunctions
 
         // Authenticate the request
         var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
-        if (authErrorResponse != null)
+        if (authErrorResponse is not null)
+        {
+            _logger.LogInformation("AnalyzeComments auth failed after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
             return authErrorResponse;
+        }
         var authElapsedMs = stopwatch.ElapsedMilliseconds;
 
         // Validate usage limits
         var usageValidationResponse = await req.ValidateUsageAsync(user!, UsageType.Analysis, _userAccountService, _logger);
-        if (usageValidationResponse != null)
+        if (usageValidationResponse is not null)
+        {
+            _logger.LogInformation("AnalyzeComments usage validation rejected after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
             return usageValidationResponse;
+        }
         var usageValidationElapsedMs = stopwatch.ElapsedMilliseconds;
 
         try
@@ -602,15 +608,17 @@ public class FeedbackFunctions
             
             // Track usage on successful completion
             await user!.TrackUsageAsync(UsageType.Analysis, _userAccountService, _logger, request.ServiceType);
+            var usageTrackingElapsedMs = stopwatch.ElapsedMilliseconds;
 
             _logger.LogInformation(
-                "AnalyzeComments performance: totalMs={TotalMs}, authMs={AuthMs}, usageValidationMs={UsageValidationMs}, parseMs={ParseMs}, analysisMs={AnalysisMs}, responseWriteMs={ResponseWriteMs}, commentsLength={CommentsLength}, serviceType={ServiceType}",
-                stopwatch.ElapsedMilliseconds,
+                "AnalyzeComments performance: totalMs={TotalMs}, authMs={AuthMs}, usageValidationMs={UsageValidationMs}, parseMs={ParseMs}, analysisMs={AnalysisMs}, responseWriteMs={ResponseWriteMs}, usageTrackingMs={UsageTrackingMs}, commentsLength={CommentsLength}, serviceType={ServiceType}",
+                usageTrackingElapsedMs,
                 authElapsedMs,
                 usageValidationElapsedMs - authElapsedMs,
                 parseElapsedMs - usageValidationElapsedMs,
                 analysisElapsedMs - parseElapsedMs,
                 responseWriteElapsedMs - analysisElapsedMs,
+                usageTrackingElapsedMs - responseWriteElapsedMs,
                 request.Comments.Length,
                 request.ServiceType);
             

--- a/feedbackfunctions/OmniSearch/OmniSearchFunction.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchFunction.cs
@@ -67,8 +67,11 @@ public class OmniSearchFunction
         {
             // Authenticate the request
             var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
-            if (authErrorResponse != null)
+            if (authErrorResponse is not null)
+            {
+                _logger.LogInformation("OmniSearch auth failed after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
                 return authErrorResponse;
+            }
             var authElapsedMs = stopwatch.ElapsedMilliseconds;
 
             // Parse request (GET or POST)
@@ -87,6 +90,7 @@ public class OmniSearchFunction
 
             if (request is null || string.IsNullOrWhiteSpace(request.Query) || request.Platforms.Count == 0)
             {
+                _logger.LogInformation("OmniSearch bad request (missing query/platforms) after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
                 var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
                 await badRequestResponse.WriteStringAsync("Invalid request. 'query' and 'platforms' are required.");
                 return badRequestResponse;
@@ -102,6 +106,7 @@ public class OmniSearchFunction
 
             if (request.Platforms.Count == 0)
             {
+                _logger.LogInformation("OmniSearch bad request (no valid platforms) after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
                 var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
                 await badRequestResponse.WriteStringAsync("No valid platforms specified. Valid options: youtube, reddit, hackernews, twitter, bluesky");
                 return badRequestResponse;

--- a/feedbackfunctions/OmniSearch/OmniSearchFunction.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchFunction.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -60,6 +61,7 @@ public class OmniSearchFunction
         [HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
     {
         _logger.LogInformation("Processing omni-search request");
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
@@ -67,6 +69,7 @@ public class OmniSearchFunction
             var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
             if (authErrorResponse != null)
                 return authErrorResponse;
+            var authElapsedMs = stopwatch.ElapsedMilliseconds;
 
             // Parse request (GET or POST)
             OmniSearchRequest? request = null;
@@ -80,6 +83,7 @@ public class OmniSearchFunction
                 var requestBody = await new StreamReader(req.Body).ReadToEndAsync();
                 request = JsonSerializer.Deserialize(requestBody, FeedbackJsonContext.Default.OmniSearchRequest);
             }
+            var requestParseElapsedMs = stopwatch.ElapsedMilliseconds;
 
             if (request is null || string.IsNullOrWhiteSpace(request.Query) || request.Platforms.Count == 0)
             {
@@ -122,6 +126,7 @@ public class OmniSearchFunction
                     return forbiddenResponse;
                 }
             }
+            var platformValidationElapsedMs = stopwatch.ElapsedMilliseconds;
 
             // Validate usage limits - each platform counts as 1 usage
             var platformCount = request.Platforms.Count;
@@ -135,6 +140,7 @@ public class OmniSearchFunction
                 await usageValidationResponse.WriteAsJsonAsync(usageValidation);
                 return usageValidationResponse;
             }
+            var usageValidationElapsedMs = stopwatch.ElapsedMilliseconds;
 
             // Check if user has enough remaining usage for all platforms
             var remainingUsage = usageValidation.Limit - usageValidation.CurrentUsage;
@@ -164,16 +170,31 @@ public class OmniSearchFunction
 
             // Execute search (pass user for usage tracking)
             var result = await _omniSearchService.SearchAsync(request, user!, _userAccountService, req.FunctionContext.CancellationToken);
+            var searchElapsedMs = stopwatch.ElapsedMilliseconds;
 
             // Return results
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "application/json");
             await response.WriteStringAsync(JsonSerializer.Serialize(result, FeedbackJsonContext.Default.OmniSearchResponse));
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
+
+            _logger.LogInformation(
+                "OmniSearch performance: totalMs={TotalMs}, authMs={AuthMs}, requestParseMs={RequestParseMs}, platformValidationMs={PlatformValidationMs}, usageValidationMs={UsageValidationMs}, searchMs={SearchMs}, responseWriteMs={ResponseWriteMs}, platformCount={PlatformCount}, queryLength={QueryLength}",
+                stopwatch.ElapsedMilliseconds,
+                authElapsedMs,
+                requestParseElapsedMs - authElapsedMs,
+                platformValidationElapsedMs - requestParseElapsedMs,
+                usageValidationElapsedMs - platformValidationElapsedMs,
+                searchElapsedMs - usageValidationElapsedMs,
+                responseWriteElapsedMs - searchElapsedMs,
+                request.Platforms.Count,
+                request.Query.Length);
+
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing omni-search request");
+            _logger.LogError(ex, "Error processing omni-search request after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
             var errorResponse = req.CreateResponse(HttpStatusCode.InternalServerError);
             await errorResponse.WriteStringAsync($"An error occurred while processing your search: {ex.Message}");
             return errorResponse;

--- a/feedbackfunctions/Reports/ReportFunctions.cs
+++ b/feedbackfunctions/Reports/ReportFunctions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+using System.Net;
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
@@ -105,28 +106,44 @@ public class ReportingFunctions
         string id)
     {
         _logger.LogInformation("Getting report with ID: {Id}", id);
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
             // Try to get from cache first
             var report = await _cacheService.GetReportAsync(id);
+            var cacheLookupElapsedMs = stopwatch.ElapsedMilliseconds;
             
             if (report == null)
             {
                 _logger.LogWarning("Report with ID {Id} not found", id);
                 var notFoundResponse = req.CreateResponse(HttpStatusCode.NotFound);
                 await notFoundResponse.WriteStringAsync($"Report with ID {id} not found");
+                _logger.LogInformation(
+                    "GetReport performance: totalMs={TotalMs}, cacheLookupMs={CacheLookupMs}, found={Found}",
+                    stopwatch.ElapsedMilliseconds,
+                    cacheLookupElapsedMs,
+                    false);
                 return notFoundResponse;
             }
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "application/json");
             await response.WriteStringAsync(JsonSerializer.Serialize(report));
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
+
+            _logger.LogInformation(
+                "GetReport performance: totalMs={TotalMs}, cacheLookupMs={CacheLookupMs}, responseWriteMs={ResponseWriteMs}, found={Found}",
+                stopwatch.ElapsedMilliseconds,
+                cacheLookupElapsedMs,
+                responseWriteElapsedMs - cacheLookupElapsedMs,
+                true);
+
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving report with ID {Id}", id);
+            _logger.LogError(ex, "Error retrieving report with ID {Id} after {ElapsedMs}ms", id, stopwatch.ElapsedMilliseconds);
             var errorResponse = req.CreateResponse(HttpStatusCode.InternalServerError);
             await errorResponse.WriteStringAsync($"Error retrieving report: {ex.Message}");
             return errorResponse;
@@ -142,11 +159,13 @@ public class ReportingFunctions
         [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
     {
         _logger.LogInformation("Getting reports for authenticated user");
+        var stopwatch = Stopwatch.StartNew();
 
         // Authenticate the request
         var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
         if (authErrorResponse != null)
             return authErrorResponse;
+        var authElapsedMs = stopwatch.ElapsedMilliseconds;
 
         if (user == null)
         {
@@ -178,17 +197,29 @@ public class ReportingFunctions
                     Repo = entity.Repo
                 });
             }
+            var userRequestsQueryElapsedMs = stopwatch.ElapsedMilliseconds;
 
             if (!userReportRequests.Any())
             {
                 var emptyResponse = req.CreateResponse(HttpStatusCode.OK);
                 emptyResponse.Headers.Add("Content-Type", "application/json");
                 await emptyResponse.WriteStringAsync(JsonSerializer.Serialize(new { reports = Array.Empty<object>() }));
+                _logger.LogInformation(
+                    "GetUserReports performance: totalMs={TotalMs}, authMs={AuthMs}, userRequestsQueryMs={UserRequestsQueryMs}, cacheReadMs={CacheReadMs}, filterMs={FilterMs}, responseWriteMs={ResponseWriteMs}, requestCount={RequestCount}, matchedReportCount={MatchedReportCount}",
+                    stopwatch.ElapsedMilliseconds,
+                    authElapsedMs,
+                    userRequestsQueryElapsedMs - authElapsedMs,
+                    0,
+                    0,
+                    stopwatch.ElapsedMilliseconds - userRequestsQueryElapsedMs,
+                    0,
+                    0);
                 return emptyResponse;
             }
 
             // Get all reports from cache
             var allReports = await _cacheService.GetReportsAsync();
+            var cacheReadElapsedMs = stopwatch.ElapsedMilliseconds;
             var matchingReports = new List<object>();
 
             foreach (var report in allReports)
@@ -218,15 +249,30 @@ public class ReportingFunctions
             matchingReports = matchingReports
                 .OrderByDescending(r => ((dynamic)r).generatedAt)
                 .ToList();
+            var filterElapsedMs = stopwatch.ElapsedMilliseconds;
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "application/json");
             await response.WriteStringAsync(JsonSerializer.Serialize(new { reports = matchingReports }));
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
+
+            _logger.LogInformation(
+                "GetUserReports performance: totalMs={TotalMs}, authMs={AuthMs}, userRequestsQueryMs={UserRequestsQueryMs}, cacheReadMs={CacheReadMs}, filterMs={FilterMs}, responseWriteMs={ResponseWriteMs}, requestCount={RequestCount}, totalCachedReports={TotalCachedReports}, matchedReportCount={MatchedReportCount}",
+                stopwatch.ElapsedMilliseconds,
+                authElapsedMs,
+                userRequestsQueryElapsedMs - authElapsedMs,
+                cacheReadElapsedMs - userRequestsQueryElapsedMs,
+                filterElapsedMs - cacheReadElapsedMs,
+                responseWriteElapsedMs - filterElapsedMs,
+                userReportRequests.Count,
+                allReports.Count,
+                matchingReports.Count);
+
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting reports for user {UserId}", user.UserId);
+            _logger.LogError(ex, "Error getting reports for user {UserId} after {ElapsedMs}ms", user.UserId, stopwatch.ElapsedMilliseconds);
             var errorResponse = req.CreateResponse(HttpStatusCode.InternalServerError);
             await errorResponse.WriteStringAsync($"Error getting user reports: {ex.Message}");
             return errorResponse;

--- a/feedbackfunctions/Reports/ReportProcessorFunctions.cs
+++ b/feedbackfunctions/Reports/ReportProcessorFunctions.cs
@@ -203,12 +203,14 @@ public class ReportProcessorFunctions
             
             // Track API usage on successful completion (Reports = 2 usage points)
             await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 2, userAccountService, _logger, $"reddit:{subreddit}");
+            var usageTrackingElapsedMs = stopwatch.ElapsedMilliseconds;
 
             _logger.LogInformation(
-                "RedditReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, force={Force}, usedCachedReport={UsedCachedReport}, htmlLength={HtmlLength}",
-                stopwatch.ElapsedMilliseconds,
+                "RedditReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, usageTrackingMs={UsageTrackingMs}, force={Force}, usedCachedReport={UsedCachedReport}, htmlLength={HtmlLength}",
+                usageTrackingElapsedMs,
                 reportResolutionElapsedMs,
                 responseWriteElapsedMs - reportResolutionElapsedMs,
+                usageTrackingElapsedMs - responseWriteElapsedMs,
                 force,
                 recentReport is not null,
                 report.HtmlContent?.Length ?? 0);
@@ -319,12 +321,14 @@ public class ReportProcessorFunctions
             
             // Track API usage on successful completion (Reports = 2 usage points)
             await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 2, userAccountService, _logger, $"github:{normalizedRepo}");
+            var usageTrackingElapsedMs = stopwatch.ElapsedMilliseconds;
 
             _logger.LogInformation(
-                "GitHubIssuesReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, force={Force}, usedCachedReport={UsedCachedReport}, days={Days}, htmlLength={HtmlLength}",
-                stopwatch.ElapsedMilliseconds,
+                "GitHubIssuesReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, usageTrackingMs={UsageTrackingMs}, force={Force}, usedCachedReport={UsedCachedReport}, days={Days}, htmlLength={HtmlLength}",
+                usageTrackingElapsedMs,
                 reportResolutionElapsedMs,
                 responseWriteElapsedMs - reportResolutionElapsedMs,
+                usageTrackingElapsedMs - responseWriteElapsedMs,
                 force,
                 recentReport is not null,
                 days,

--- a/feedbackfunctions/Reports/ReportProcessorFunctions.cs
+++ b/feedbackfunctions/Reports/ReportProcessorFunctions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -142,6 +143,7 @@ public class ReportProcessorFunctions
         [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
     {
         var startTime = DateTime.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Starting Reddit Report processing for URL {RequestUrl}", req.Url);
 
         // Validate API key and check usage limits (Reports = 2 usage points)
@@ -188,6 +190,7 @@ public class ReportProcessorFunctions
                 var cutoffDate = DateTimeOffset.UtcNow.AddDays(-7);
                 report = await _reportGenerator.GenerateRedditReportAsync(subreddit, cutoffDate);
             }
+            var reportResolutionElapsedMs = stopwatch.ElapsedMilliseconds;
 
             var processingTime = DateTime.UtcNow - startTime;
             _logger.LogInformation("Reddit Report processing completed for r/{Subreddit} in {ProcessingTime:c}", 
@@ -196,9 +199,19 @@ public class ReportProcessorFunctions
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             await response.WriteStringAsync(report.HtmlContent ?? string.Empty);
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
             
             // Track API usage on successful completion (Reports = 2 usage points)
             await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 2, userAccountService, _logger, $"reddit:{subreddit}");
+
+            _logger.LogInformation(
+                "RedditReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, force={Force}, usedCachedReport={UsedCachedReport}, htmlLength={HtmlLength}",
+                stopwatch.ElapsedMilliseconds,
+                reportResolutionElapsedMs,
+                responseWriteElapsedMs - reportResolutionElapsedMs,
+                force,
+                recentReport is not null,
+                report.HtmlContent?.Length ?? 0);
             
             return response;
         }
@@ -234,6 +247,7 @@ public class ReportProcessorFunctions
         [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
     {
         var startTime = DateTime.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Starting GitHub Issues Report processing for URL {RequestUrl}", req.Url);
 
         // Validate API key and check usage limits (Reports = 2 usage points)
@@ -292,6 +306,7 @@ public class ReportProcessorFunctions
                 _logger.LogInformation(logMessage, repoOwner, repoName);
                 report = await _reportGenerator.GenerateGitHubReportAsync(repoOwner, repoName, days);
             }
+            var reportResolutionElapsedMs = stopwatch.ElapsedMilliseconds;
 
             var processingTime = DateTime.UtcNow - startTime;
             _logger.LogInformation("GitHub Issues Report processing completed for {RepoOwner}/{RepoName} in {ProcessingTime:c}", 
@@ -300,9 +315,20 @@ public class ReportProcessorFunctions
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             await response.WriteStringAsync(report.HtmlContent ?? string.Empty);
+            var responseWriteElapsedMs = stopwatch.ElapsedMilliseconds;
             
             // Track API usage on successful completion (Reports = 2 usage points)
             await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 2, userAccountService, _logger, $"github:{normalizedRepo}");
+
+            _logger.LogInformation(
+                "GitHubIssuesReport performance: totalMs={TotalMs}, reportResolutionMs={ReportResolutionMs}, responseWriteMs={ResponseWriteMs}, force={Force}, usedCachedReport={UsedCachedReport}, days={Days}, htmlLength={HtmlLength}",
+                stopwatch.ElapsedMilliseconds,
+                reportResolutionElapsedMs,
+                responseWriteElapsedMs - reportResolutionElapsedMs,
+                force,
+                recentReport is not null,
+                days,
+                report.HtmlContent?.Length ?? 0);
             
             return response;
         }

--- a/feedbackfunctions/Services/Reports/ReportCacheService.cs
+++ b/feedbackfunctions/Services/Reports/ReportCacheService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text.Json;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging;
@@ -34,11 +35,17 @@ public class ReportCacheService : IReportCacheService
     /// <inheritdoc />
     public async Task<ReportModel?> GetReportAsync(string reportId)
     {
+        var stopwatch = Stopwatch.StartNew();
         await EnsureCacheIsValidAsync();
 
         if (_cache.TryGetValue(reportId, out var cachedReport))
         {
             _logger.LogDebug("Cache hit for report {ReportId}", reportId);
+            _logger.LogInformation(
+                "ReportCache.GetReportAsync performance: totalMs={TotalMs}, cacheHit={CacheHit}, reportId={ReportId}",
+                stopwatch.ElapsedMilliseconds,
+                true,
+                reportId);
             return cachedReport.Report;
         }
 
@@ -58,6 +65,12 @@ public class ReportCacheService : IReportCacheService
                     // Add to cache
                     _cache.TryAdd(reportId, new CachedReport(report, DateTime.UtcNow));
                     _logger.LogDebug("Loaded and cached report {ReportId} from blob storage", reportId);
+                    _logger.LogInformation(
+                        "ReportCache.GetReportAsync performance: totalMs={TotalMs}, cacheHit={CacheHit}, blobFallback={BlobFallback}, reportId={ReportId}",
+                        stopwatch.ElapsedMilliseconds,
+                        false,
+                        true,
+                        reportId);
                     return report;
                 }
             }
@@ -67,6 +80,12 @@ public class ReportCacheService : IReportCacheService
             _logger.LogWarning(ex, "Failed to load report {ReportId} from blob storage", reportId);
         }
 
+        _logger.LogInformation(
+            "ReportCache.GetReportAsync performance: totalMs={TotalMs}, cacheHit={CacheHit}, blobFallback={BlobFallback}, reportId={ReportId}",
+            stopwatch.ElapsedMilliseconds,
+            false,
+            false,
+            reportId);
         return null;
     }
 
@@ -139,6 +158,7 @@ public class ReportCacheService : IReportCacheService
     /// <inheritdoc />
     public async Task RefreshCacheAsync()
     {
+        var stopwatch = Stopwatch.StartNew();
         await _refreshSemaphore.WaitAsync();
         try
         {
@@ -167,7 +187,10 @@ public class ReportCacheService : IReportCacheService
             }
 
             _lastRefresh = DateTime.UtcNow;
-            _logger.LogInformation("Cache refresh completed. Loaded {Count} reports", loadedCount);
+            _logger.LogInformation(
+                "Cache refresh completed. Loaded {Count} reports in {ElapsedMs}ms",
+                loadedCount,
+                stopwatch.ElapsedMilliseconds);
         }
         finally
         {
@@ -180,6 +203,7 @@ public class ReportCacheService : IReportCacheService
     /// </summary>
     private async Task EnsureCacheIsValidAsync()
     {
+        var stopwatch = Stopwatch.StartNew();
         // Only refresh if cache is completely empty and has never been refreshed
         // This prevents automatic refresh during testing
         if (_cache.IsEmpty && _lastRefresh == DateTime.MinValue)
@@ -187,6 +211,9 @@ public class ReportCacheService : IReportCacheService
             try
             {
                 await RefreshCacheAsync();
+                _logger.LogInformation(
+                    "ReportCache.EnsureCacheIsValidAsync triggered initial refresh in {ElapsedMs}ms",
+                    stopwatch.ElapsedMilliseconds);
             }
             catch (Exception ex)
             {
@@ -199,6 +226,9 @@ public class ReportCacheService : IReportCacheService
             try
             {
                 await RefreshCacheAsync();
+                _logger.LogInformation(
+                    "ReportCache.EnsureCacheIsValidAsync refreshed expired cache in {ElapsedMs}ms",
+                    stopwatch.ElapsedMilliseconds);
             }
             catch (Exception ex)
             {

--- a/feedbackfunctions/Services/Reports/ReportCacheService.cs
+++ b/feedbackfunctions/Services/Reports/ReportCacheService.cs
@@ -235,6 +235,12 @@ public class ReportCacheService : IReportCacheService
                 _logger.LogWarning(ex, "Failed to refresh expired cache, continuing with existing cache");
             }
         }
+        else
+        {
+            _logger.LogDebug(
+                "ReportCache.EnsureCacheIsValidAsync cache is valid, checked in {ElapsedMs}ms",
+                stopwatch.ElapsedMilliseconds);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Adds Stopwatch-based timing instrumentation to key Azure Functions backend endpoints, establishing a performance baseline for future optimization work.

Closes #224

## Changes

### Instrumented Endpoints
- **AnalyzeComments** — auth, usage validation, request parsing, AI analysis, response write, usage tracking
- **OmniSearch** — auth, request parsing, platform validation, usage validation, search execution, response write
- **GetReport / GetUserReports** — auth, cache lookup, response serialization
- **RedditReport / GitHubIssuesReport** — report resolution (cache vs generation), response write, usage tracking
- **ReportCacheService** — GetReportAsync, RefreshCacheAsync, EnsureCacheIsValidAsync

### Instrumentation Details
- Uses \System.Diagnostics.Stopwatch\ for high-resolution timing
- Structured logging with named parameters for easy querying (e.g. \	otalMs={TotalMs}\)
- Each phase captured as a delta so metrics sum to total
- Early-return paths (auth failures, validation errors) include timing
- Error paths log elapsed time for diagnosing slow failures
- Cache validation logs at Debug level for the common cache-valid path

### Example Log Output
\\\
AnalyzeComments performance: totalMs=1234, authMs=15, usageValidationMs=8, parseMs=2, analysisMs=1180, responseWriteMs=12, usageTrackingMs=17, commentsLength=4500, serviceType=GitHub
\\\

## Testing
- Build succeeds with 0 errors
- All 265 tests pass