### PR TITLE
Reduce Functions startup storage overhead

### DIFF
--- a/feedbackflow.tests/TableInitializationServiceTests.cs
+++ b/feedbackflow.tests/TableInitializationServiceTests.cs
@@ -1,0 +1,181 @@
+using System.Threading;
+
+using Azure;
+using Azure.Data.Tables;
+using Azure.Data.Tables.Models;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+using FeedbackFunctions.Services.Storage;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using NSubstitute;
+
+namespace FeedbackFlow.Tests;
+
+[TestClass]
+public class TableInitializationServiceTests
+{
+    [TestMethod]
+    public async Task EnsureAccountTablesAsync_WhenCalledConcurrently_InitializesEachTableOnce()
+    {
+        var userAccountsTable = Substitute.For<TableClient>();
+        var usageRecordsTable = Substitute.For<TableClient>();
+        var apiKeysTable = Substitute.For<TableClient>();
+
+        var storage = CreateStorage(
+            userAccountsTable: userAccountsTable,
+            usageRecordsTable: usageRecordsTable,
+            apiKeysTable: apiKeysTable);
+
+        var service = new TableInitializationService(
+            storage,
+            Substitute.For<ILogger<TableInitializationService>>());
+
+        var userAccountsCalls = 0;
+        var usageRecordsCalls = 0;
+        var apiKeysCalls = 0;
+
+        userAccountsTable
+            .CreateIfNotExistsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref userAccountsCalls);
+                return Task.FromResult<Response<TableItem>>(null!);
+            });
+
+        usageRecordsTable
+            .CreateIfNotExistsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref usageRecordsCalls);
+                return Task.FromResult<Response<TableItem>>(null!);
+            });
+
+        apiKeysTable
+            .CreateIfNotExistsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref apiKeysCalls);
+                return Task.FromResult<Response<TableItem>>(null!);
+            });
+
+        await Task.WhenAll(
+            service.EnsureAccountTablesAsync(),
+            service.EnsureAccountTablesAsync(),
+            service.EnsureAccountTablesAsync());
+
+        Assert.AreEqual(1, userAccountsCalls);
+        Assert.AreEqual(1, usageRecordsCalls);
+        Assert.AreEqual(1, apiKeysCalls);
+    }
+
+    [TestMethod]
+    public async Task EnsureReportStorageAsync_WhenCalledMultipleTimes_InitializesAllResourcesOnce()
+    {
+        var reportRequestsTable = Substitute.For<TableClient>();
+        var userReportRequestsTable = Substitute.For<TableClient>();
+        var reportsContainer = Substitute.For<BlobContainerClient>();
+        var reportsSummaryContainer = Substitute.For<BlobContainerClient>();
+        var weeklySummariesContainer = Substitute.For<BlobContainerClient>();
+
+        var storage = CreateStorage(
+            reportRequestsTable: reportRequestsTable,
+            userReportRequestsTable: userReportRequestsTable,
+            reportsContainer: reportsContainer,
+            reportsSummaryContainer: reportsSummaryContainer,
+            weeklySummariesContainer: weeklySummariesContainer);
+
+        var service = new TableInitializationService(
+            storage,
+            Substitute.For<ILogger<TableInitializationService>>());
+
+        var reportRequestsCalls = 0;
+        var userReportRequestsCalls = 0;
+        var reportsContainerCalls = 0;
+        var reportsSummaryCalls = 0;
+        var weeklySummariesCalls = 0;
+
+        reportRequestsTable
+            .CreateIfNotExistsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref reportRequestsCalls);
+                return Task.FromResult<Response<TableItem>>(null!);
+            });
+
+        userReportRequestsTable
+            .CreateIfNotExistsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref userReportRequestsCalls);
+                return Task.FromResult<Response<TableItem>>(null!);
+            });
+
+        reportsContainer
+            .CreateIfNotExistsAsync(Arg.Any<PublicAccessType>(), Arg.Any<IDictionary<string, string>>(), Arg.Any<BlobContainerEncryptionScopeOptions>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref reportsContainerCalls);
+                return Task.FromResult<Response<Azure.Storage.Blobs.Models.BlobContainerInfo>>(null!);
+            });
+
+        reportsSummaryContainer
+            .CreateIfNotExistsAsync(Arg.Any<PublicAccessType>(), Arg.Any<IDictionary<string, string>>(), Arg.Any<BlobContainerEncryptionScopeOptions>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref reportsSummaryCalls);
+                return Task.FromResult<Response<Azure.Storage.Blobs.Models.BlobContainerInfo>>(null!);
+            });
+
+        weeklySummariesContainer
+            .CreateIfNotExistsAsync(Arg.Any<PublicAccessType>(), Arg.Any<IDictionary<string, string>>(), Arg.Any<BlobContainerEncryptionScopeOptions>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref weeklySummariesCalls);
+                return Task.FromResult<Response<Azure.Storage.Blobs.Models.BlobContainerInfo>>(null!);
+            });
+
+        await service.EnsureReportStorageAsync();
+        await service.EnsureReportStorageAsync();
+
+        Assert.AreEqual(1, reportRequestsCalls);
+        Assert.AreEqual(1, userReportRequestsCalls);
+        Assert.AreEqual(1, reportsContainerCalls);
+        Assert.AreEqual(1, reportsSummaryCalls);
+        Assert.AreEqual(1, weeklySummariesCalls);
+    }
+
+    private static FeedbackStorageClients CreateStorage(
+        TableClient? userAccountsTable = null,
+        TableClient? usageRecordsTable = null,
+        TableClient? apiKeysTable = null,
+        TableClient? authUsersTable = null,
+        TableClient? reportRequestsTable = null,
+        TableClient? userReportRequestsTable = null,
+        TableClient? adminReportConfigsTable = null,
+        TableClient? sharedAnalysesTable = null,
+        BlobContainerClient? reportsContainer = null,
+        BlobContainerClient? reportsSummaryContainer = null,
+        BlobContainerClient? weeklySummariesContainer = null,
+        BlobContainerClient? sharedAnalysesContainer = null)
+    {
+        return new FeedbackStorageClients(
+            blobServiceClient: null,
+            tableServiceClient: null,
+            reportsContainer: reportsContainer ?? Substitute.For<BlobContainerClient>(),
+            reportsSummaryContainer: reportsSummaryContainer ?? Substitute.For<BlobContainerClient>(),
+            weeklySummariesContainer: weeklySummariesContainer ?? Substitute.For<BlobContainerClient>(),
+            sharedAnalysesContainer: sharedAnalysesContainer ?? Substitute.For<BlobContainerClient>(),
+            userAccountsTable: userAccountsTable ?? Substitute.For<TableClient>(),
+            usageRecordsTable: usageRecordsTable ?? Substitute.For<TableClient>(),
+            apiKeysTable: apiKeysTable ?? Substitute.For<TableClient>(),
+            authUsersTable: authUsersTable ?? Substitute.For<TableClient>(),
+            reportRequestsTable: reportRequestsTable ?? Substitute.For<TableClient>(),
+            userReportRequestsTable: userReportRequestsTable ?? Substitute.For<TableClient>(),
+            adminReportConfigsTable: adminReportConfigsTable ?? Substitute.For<TableClient>(),
+            sharedAnalysesTable: sharedAnalysesTable ?? Substitute.For<TableClient>());
+    }
+}

--- a/feedbackfunctions/Account/AuthUserManagement.cs
+++ b/feedbackfunctions/Account/AuthUserManagement.cs
@@ -17,6 +17,7 @@ using FeedbackFunctions.Models;
 using SharedDump.Models.Reports;
 using SharedDump.Models;
 using FeedbackFunctions.Extensions;
+using FeedbackFunctions.Services.Storage;
 
 namespace FeedbackFunctions.Account;
 
@@ -29,8 +30,8 @@ public class AuthUserManagement : IDisposable
     private readonly FeedbackFunctions.Middleware.AuthenticationMiddleware _authMiddleware;
     private readonly IAuthUserTableService _userService;
     private readonly IUserAccountService _userAccountService;
-    private readonly BlobServiceClient _blobServiceClient;
-    private readonly TableServiceClient _tableServiceClient;
+    private readonly FeedbackStorageClients _storage;
+    private readonly ITableInitializationService _tableInitializationService;
     private readonly SemaphoreSlim _registrationSemaphore = new SemaphoreSlim(1, 1);
     private readonly bool _allowsRegistration;
     
@@ -43,22 +44,19 @@ public class AuthUserManagement : IDisposable
         FeedbackFunctions.Middleware.AuthenticationMiddleware authMiddleware,
         IAuthUserTableService userService,
         IUserAccountService userAccountService,
+        FeedbackStorageClients storage,
+        ITableInitializationService tableInitializationService,
         IConfiguration configuration)
     {
         _logger = logger;
         _authMiddleware = authMiddleware;
         _userService = userService;
         _userAccountService = userAccountService;
+        _storage = storage;
+        _tableInitializationService = tableInitializationService;
         
         // Get registration setting with default to true
         _allowsRegistration = configuration.GetValue<bool>("AllowsRegistration", true);
-        
-        // Create storage clients using connection string, following the pattern from other services
-        var storageConnection = configuration["ProductionStorage"] ??
-                              throw new InvalidOperationException("No storage connection string configured");
-        
-        _blobServiceClient = new BlobServiceClient(storageConnection);
-        _tableServiceClient = new TableServiceClient(storageConnection);
     }
 
     /// <summary>
@@ -335,9 +333,11 @@ public class AuthUserManagement : IDisposable
         try
         {
             _logger.LogInformation("Deleting shared analyses for user {UserId}", userId);
-            
-            var containerClient = _blobServiceClient.GetBlobContainerClient("shared-analyses");
-            var sharedAnalysesTableClient = _tableServiceClient.GetTableClient("SharedAnalyses");
+
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
+            var containerClient = _storage.SharedAnalysesContainer;
+            var sharedAnalysesTableClient = _storage.SharedAnalysesTable;
             
             var containerExists = await containerClient.ExistsAsync();
             
@@ -402,20 +402,11 @@ public class AuthUserManagement : IDisposable
         try
         {
             _logger.LogInformation("Deleting report requests for user {UserId}", userId);
-            
-            var globalTableClient = _tableServiceClient.GetTableClient("reportrequests");
-            var userTableClient = _tableServiceClient.GetTableClient("userreportrequests");
-            
-            // Try to ensure tables exist, but continue if they don't
-            try
-            {
-                await globalTableClient.CreateIfNotExistsAsync();
-                await userTableClient.CreateIfNotExistsAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Could not verify table existence, proceeding anyway");
-            }
+
+            await _tableInitializationService.EnsureReportStorageAsync();
+
+            var globalTableClient = _storage.ReportRequestsTable;
+            var userTableClient = _storage.UserReportRequestsTable;
 
             var deletedUserRequestsCount = 0;
             var updatedGlobalRequestsCount = 0;

--- a/feedbackfunctions/Email/DigestEmailProcessorFunction.cs
+++ b/feedbackfunctions/Email/DigestEmailProcessorFunction.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using FeedbackFunctions.Services.Email;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Reports;
+using FeedbackFunctions.Services.Storage;
 using FeedbackFunctions.Utils;
 using System.Text.Json;
 
@@ -23,8 +24,8 @@ public class DigestEmailProcessorFunction
 {
     private readonly ILogger<DigestEmailProcessorFunction> _logger;
     private readonly IConfiguration _configuration;
-    private readonly TableClient _userAccountsTableClient;
-    private readonly TableClient _userRequestsTableClient;
+    private readonly FeedbackStorageClients _storage;
+    private readonly ITableInitializationService _tableInitializationService;
     private readonly IReportCacheService _reportCacheService;
     private readonly IEmailService _emailService;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -32,31 +33,17 @@ public class DigestEmailProcessorFunction
     public DigestEmailProcessorFunction(
         ILogger<DigestEmailProcessorFunction> logger,
         IConfiguration configuration,
+        FeedbackStorageClients storage,
+        ITableInitializationService tableInitializationService,
         IEmailService emailService,
         IReportCacheService reportCacheService)
     {
         _logger = logger;
+        _configuration = configuration;
+        _storage = storage;
+        _tableInitializationService = tableInitializationService;
         _emailService = emailService;
         _reportCacheService = reportCacheService;
-        
-#if DEBUG
-        _configuration = new ConfigurationBuilder()
-                    .AddJsonFile("local.settings.json")
-                    .AddUserSecrets<Program>()
-                    .Build();
-#else
-        _configuration = configuration;
-#endif
-
-        // Initialize table clients
-        var storageConnection = _configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var tableServiceClient = new TableServiceClient(storageConnection);
-        
-        _userAccountsTableClient = tableServiceClient.GetTableClient("useraccounts");
-        _userAccountsTableClient.CreateIfNotExists();
-        
-        _userRequestsTableClient = tableServiceClient.GetTableClient("userreportrequests");
-        _userRequestsTableClient.CreateIfNotExists();
     }
 
     /// <summary>
@@ -113,6 +100,9 @@ public class DigestEmailProcessorFunction
     {
         try
         {
+            await _tableInitializationService.EnsureAccountTablesAsync();
+            await _tableInitializationService.EnsureReportStorageAsync();
+
             var cutoffDate = DateTime.UtcNow.AddDays(-7); // Only reports from the last week
             _logger.LogInformation("Processing individual report emails for reports since {CutoffDate}", cutoffDate);
 
@@ -121,7 +111,7 @@ public class DigestEmailProcessorFunction
             var emailsSent = 0;
             var usersProcessed = 0;
 
-            await foreach (var userRequest in _userRequestsTableClient.QueryAsync<UserReportRequestModel>(filter))
+            await foreach (var userRequest in _storage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(filter))
             {
                 try
                 {
@@ -129,7 +119,7 @@ public class DigestEmailProcessorFunction
                     var userId = userRequest.UserId;
                     
                     // Get user account to check tier, email settings, and email address
-                    var userAccountEntity = await _userAccountsTableClient.GetEntityAsync<UserAccountEntity>(userId, "account");
+                    var userAccountEntity = await _storage.UserAccountsTable.GetEntityAsync<UserAccountEntity>(userId, "account");
                     
                     // Check if user's tier supports email notifications
                     if (!AccountTierUtils.SupportsEmailNotifications((AccountTier)userAccountEntity.Value.Tier))
@@ -207,7 +197,7 @@ public class DigestEmailProcessorFunction
 
                     // Update last email sent timestamp
                     userAccountEntity.Value.LastEmailSent = DateTime.UtcNow;
-                    await _userAccountsTableClient.UpdateEntityAsync(userAccountEntity.Value, userAccountEntity.Value.ETag);
+                    await _storage.UserAccountsTable.UpdateEntityAsync(userAccountEntity.Value, userAccountEntity.Value.ETag);
                 }
                 catch (Exception ex)
                 {
@@ -231,6 +221,9 @@ public class DigestEmailProcessorFunction
     {
         try
         {
+            await _tableInitializationService.EnsureAccountTablesAsync();
+            await _tableInitializationService.EnsureReportStorageAsync();
+
             var cutoffDate = DateTime.UtcNow.AddDays(-7); // Only reports from the last week
             _logger.LogInformation("Processing weekly digest emails for reports since {CutoffDate}", cutoffDate);
 
@@ -238,7 +231,7 @@ public class DigestEmailProcessorFunction
             var digestRequests = new Dictionary<string, List<UserReportRequestModel>>();
             var filter = "EmailEnabled eq true";
 
-            await foreach (var userRequest in _userRequestsTableClient.QueryAsync<UserReportRequestModel>(filter))
+            await foreach (var userRequest in _storage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(filter))
             {
                 if (!digestRequests.ContainsKey(userRequest.UserId))
                 {
@@ -259,7 +252,7 @@ public class DigestEmailProcessorFunction
                     var userRequests = userDigestGroup.Value;
                     
                     // Get user account to check tier, email settings, and email address
-                    var userAccountEntity = await _userAccountsTableClient.GetEntityAsync<UserAccountEntity>(userId, "account");
+                    var userAccountEntity = await _storage.UserAccountsTable.GetEntityAsync<UserAccountEntity>(userId, "account");
                     
                     // Check if user's tier supports email notifications
                     if (!AccountTierUtils.SupportsEmailNotifications((AccountTier)userAccountEntity.Value.Tier))
@@ -328,7 +321,7 @@ public class DigestEmailProcessorFunction
 
                         // Update last email sent timestamp
                         userAccountEntity.Value.LastEmailSent = DateTime.UtcNow;
-                        await _userAccountsTableClient.UpdateEntityAsync(userAccountEntity.Value, userAccountEntity.Value.ETag);
+                        await _storage.UserAccountsTable.UpdateEntityAsync(userAccountEntity.Value, userAccountEntity.Value.ETag);
                     }
                     else
                     {

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -18,9 +20,10 @@ using FeedbackFunctions.Services.Authentication;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Email;
+using FeedbackFunctions.Services.Storage;
 using System.Configuration;
-using Azure.Storage.Blobs;
 using FeedbackFunctions.Services.Reports;
+using FeedbackFunctions.Utils;
 using FeedbackFunctions.OmniSearch;
 
 var builder = FunctionsApplication.CreateBuilder(args);
@@ -52,26 +55,21 @@ builder.Services.ConfigureHttpClientDefaults(http =>
 });
 
 // Register authentication services
-builder.Services.AddScoped<IAuthUserTableService, AuthUserTableService>();
 builder.Services.AddScoped<FeedbackFunctions.Middleware.AuthenticationMiddleware>();
 
-// Register unified account service
+RegisterStorageServices(builder.Services);
 RegisterAccountServices(builder.Services);
 
 // Register blob storage and cache services
 builder.Services.AddSingleton<IReportCacheService>(serviceProvider =>
 {
-    var configuration = GetConfig(serviceProvider);
     var logger = serviceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<ReportCacheService>>();
-    var storageConnection = configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-    var serviceClient = new BlobServiceClient(storageConnection);
-    var containerClient = serviceClient.GetBlobContainerClient("reports");
-    containerClient.CreateIfNotExists();
-    return new ReportCacheService(logger, containerClient);
+    var reportStorage = serviceProvider.GetRequiredService<IReportStorageService>();
+    return new ReportCacheService(logger, reportStorage.ReportsContainer, reportStorage);
 });
 
 // Register admin report config service
-builder.Services.AddScoped<IAdminReportConfigService, AdminReportConfigService>();
+builder.Services.AddSingleton<IAdminReportConfigService, AdminReportConfigService>();
 
 // Register OmniSearch service
 builder.Services.AddScoped<OmniSearchService>();
@@ -89,9 +87,6 @@ if (useMocks)
     builder.Services.AddScoped<ITwitterService, MockTwitterService>();
     builder.Services.AddScoped<IBlueSkyService, MockBlueSkyService>();
     builder.Services.AddScoped<IEmailService, MockEmailService>();
-    
-    // Register unified account service
-    RegisterAccountServices(builder.Services);
 }
 else
 {
@@ -229,10 +224,17 @@ else
         
         return new EmailService(configuration, logger);
     });
-    
-    // Register unified account service
-    RegisterAccountServices(builder.Services);
 }
+
+builder.Services.AddScoped<ReportGenerator>(serviceProvider =>
+    new ReportGenerator(
+        serviceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<ReportGenerator>>(),
+        serviceProvider.GetRequiredService<IRedditService>(),
+        serviceProvider.GetRequiredService<IGitHubService>(),
+        serviceProvider.GetRequiredService<IFeedbackAnalyzerService>(),
+        serviceProvider.GetRequiredService<IReportStorageService>(),
+        GetConfig(serviceProvider),
+        serviceProvider.GetService<IReportCacheService>()));
 
 IConfiguration GetConfig(IServiceProvider? serviceProvider = null)
 {
@@ -243,19 +245,46 @@ IConfiguration GetConfig(IServiceProvider? serviceProvider = null)
 #endif
 }
 
+void RegisterStorageServices(IServiceCollection services)
+{
+    services.AddSingleton(sp =>
+    {
+        var config = GetConfig(sp);
+        var storage = config["ProductionStorage"] ?? "UseDevelopmentStorage=true";
+        return new BlobServiceClient(storage);
+    });
+
+    services.AddSingleton(sp =>
+    {
+        var config = GetConfig(sp);
+        var storage = config["ProductionStorage"] ?? "UseDevelopmentStorage=true";
+        return new TableServiceClient(storage);
+    });
+
+    services.AddSingleton<FeedbackStorageClients>();
+    services.AddSingleton<ITableInitializationService, TableInitializationService>();
+    services.AddSingleton<IReportStorageService, ReportStorageService>();
+}
+
 void RegisterAccountServices(IServiceCollection services)
 {
-    // Register the unified user account service
     services.AddSingleton<IUserAccountService>(sp =>
     {
         var config = GetConfig(sp);
         var logger = sp.GetService<Microsoft.Extensions.Logging.ILogger<UserAccountService>>();
-        var storage = config["ProductionStorage"] ?? "UseDevelopmentStorage=true";
-        return new UserAccountService(storage, config, logger);
+        var storageClients = sp.GetRequiredService<FeedbackStorageClients>();
+        var initializer = sp.GetRequiredService<ITableInitializationService>();
+        return new UserAccountService(
+            storageClients.UserAccountsTable,
+            storageClients.UsageRecordsTable,
+            storageClients.ApiKeysTable,
+            initializer,
+            config,
+            logger);
     });
-    
-    // Register the API key service
-    services.AddScoped<IApiKeyService, ApiKeyService>();
+
+    services.AddSingleton<IAuthUserTableService, AuthUserTableService>();
+    services.AddSingleton<IApiKeyService, ApiKeyService>();
 }
 
 // Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4.
@@ -264,12 +293,5 @@ builder.Services
     .ConfigureFunctionsApplicationInsights();
 
 var app = builder.Build();
-
-// Ensure tables exist on startup
-using (var scope = app.Services.CreateScope())
-{
-    var userAccountService = scope.ServiceProvider.GetRequiredService<IUserAccountService>();
-    await userAccountService.InitializeTablesAsync();
-}
 
 app.Run();

--- a/feedbackfunctions/Reports/AdminReportProcessorFunction.cs
+++ b/feedbackfunctions/Reports/AdminReportProcessorFunction.cs
@@ -4,12 +4,10 @@ using Microsoft.Extensions.Logging;
 using FeedbackFunctions.Services.Reports;
 using FeedbackFunctions.Services.Email;
 using SharedDump.Services.Interfaces;
-using SharedDump.AI;
 using FeedbackFunctions.Services;
 using FeedbackFunctions.Utils;
 using SharedDump.Models.Reports;
 using FeedbackFunctions.Models.Email;
-using Azure.Storage.Blobs;
 using System.Net;
 using Microsoft.AspNetCore.WebUtilities;
 using FeedbackFunctions.Attributes;
@@ -40,28 +38,19 @@ public class AdminReportProcessorFunction
         IAdminReportConfigService adminReportConfigService,
         IReportCacheService cacheService,
         IEmailService emailService,
-        IRedditService redditService,
-        IGitHubService githubService,
-    IFeedbackAnalyzerService analyzerService,
-    Microsoft.Extensions.Configuration.IConfiguration configuration,
-    AuthenticationMiddleware authMiddleware,
-    IUserAccountService userAccountService)
+        ReportGenerator reportGenerator,
+        Microsoft.Extensions.Configuration.IConfiguration configuration,
+        AuthenticationMiddleware authMiddleware,
+        IUserAccountService userAccountService)
     {
         _logger = logger;
         _adminReportConfigService = adminReportConfigService;
         _cacheService = cacheService;
         _emailService = emailService;
+        _reportGenerator = reportGenerator;
         _authMiddleware = authMiddleware;
         _userAccountService = userAccountService;
         _configuration = configuration;
-        
-        // Initialize ReportGenerator with required dependencies
-        var storageConnection = configuration["ProductionStorage"] ?? 
-                              throw new InvalidOperationException("ProductionStorage connection string not found");
-        var blobServiceClient = new Azure.Storage.Blobs.BlobServiceClient(storageConnection);
-        
-        _reportGenerator = new ReportGenerator(logger, redditService, githubService, analyzerService, 
-                                             blobServiceClient, configuration, cacheService);
     }
 
     /// <summary>

--- a/feedbackfunctions/Reports/ReportFunctions.cs
+++ b/feedbackfunctions/Reports/ReportFunctions.cs
@@ -1,19 +1,13 @@
-using System.Net;
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using SharedDump.Models.Reddit;
-using SharedDump.Models.GitHub;
 using SharedDump.Models.Reports;
-using SharedDump.AI;
 using SharedDump.Services;
-using SharedDump.Services.Interfaces;
 using SharedDump.Utils;
-using Azure.Storage.Blobs;
 using FeedbackFunctions.Utils;
 using FeedbackFunctions.Services;
 using FeedbackFunctions.Services.Reports;
@@ -35,14 +29,9 @@ namespace FeedbackFunctions;
 public class ReportingFunctions
 {
     private readonly ILogger<ReportingFunctions> _logger;
-    private readonly IRedditService _redditService;
-    private readonly IGitHubService _githubService;
-    private readonly IFeedbackAnalyzerService _analyzerService;
-    private readonly IConfiguration _configuration;
     private readonly IReportCacheService _cacheService;
+    private readonly IReportStorageService _reportStorage;
     private readonly FeedbackFunctions.Middleware.AuthenticationMiddleware _authMiddleware;
-    private const string ContainerName = "reports";
-    private readonly BlobContainerClient _containerClient;
     private readonly ReportGenerator _reportGenerator;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -58,39 +47,16 @@ public class ReportingFunctions
     /// <param name="authMiddleware">Authentication middleware for request validation</param>
     public ReportingFunctions(
         ILogger<ReportingFunctions> logger,
-        IConfiguration configuration,
-        IRedditService redditService,
-        IGitHubService githubService,
-        IFeedbackAnalyzerService analyzerService,
+        IReportStorageService reportStorage,
         IReportCacheService cacheService,
-        FeedbackFunctions.Middleware.AuthenticationMiddleware authMiddleware)
+        FeedbackFunctions.Middleware.AuthenticationMiddleware authMiddleware,
+        ReportGenerator reportGenerator)
     {
-
-#if DEBUG
-
-        _configuration = new ConfigurationBuilder()
-                    .AddJsonFile("local.settings.json")
-                    .AddUserSecrets<Program>()
-                    .Build();
-#else
-
-        _configuration = configuration;
-#endif
         _logger = logger;
-        _redditService = redditService;
-        _githubService = githubService;
-        _analyzerService = analyzerService;
+        _reportStorage = reportStorage;
         _cacheService = cacheService;
         _authMiddleware = authMiddleware;
-        
-        // Initialize blob container
-        var storageConnection = _configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var serviceClient = new BlobServiceClient(storageConnection);
-        _containerClient = serviceClient.GetBlobContainerClient(ContainerName);
-        _containerClient.CreateIfNotExists();
-
-        // Initialize report generator
-        _reportGenerator = new ReportGenerator(_logger, _redditService, _githubService, _analyzerService, serviceClient, _configuration, _cacheService);
+        _reportGenerator = reportGenerator;
     }
 
   
@@ -176,16 +142,13 @@ public class ReportingFunctions
 
         try
         {
+            await _reportStorage.EnsureInitializedAsync();
+
             // Get user's report requests instead of parsing from request body
             // This ensures we only return reports for sources the user has actually requested
             var userReportRequests = new List<ReportRequestModel>();
-            
-            // Connect to user requests table
-            var storageConnection = _configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-            var tableServiceClient = new Azure.Data.Tables.TableServiceClient(storageConnection);
-            var userRequestsTableClient = tableServiceClient.GetTableClient("userreportrequests");
 
-            await foreach (var entity in userRequestsTableClient.QueryAsync<UserReportRequestModel>(
+            await foreach (var entity in _reportStorage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(
                 filter: $"PartitionKey eq '{user.UserId}'"))
             {
                 // Convert user request to ReportRequestModel for consistency

--- a/feedbackfunctions/Reports/ReportProcessorFunctions.cs
+++ b/feedbackfunctions/Reports/ReportProcessorFunctions.cs
@@ -1,24 +1,20 @@
-using System.Net;
 using System.Diagnostics;
+using System.Net;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Logging;
-using SharedDump.Models.Reports;
-using SharedDump.Models.Account;
-using SharedDump.Utils.Account;
 using Azure.Data.Tables;
-using Azure.Storage.Blobs;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using SharedDump.Services.Interfaces;
-using SharedDump.AI;
+using Microsoft.Extensions.Logging;
 using FeedbackFunctions.Utils;
 using FeedbackFunctions.Services;
 using FeedbackFunctions.Services.Reports;
 using FeedbackFunctions.Services.Email;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Models.Email;
+using SharedDump.Models.Account;
+using SharedDump.Models.Reports;
+using SharedDump.Utils.Account;
 
 namespace FeedbackFunctions;
 
@@ -28,12 +24,7 @@ namespace FeedbackFunctions;
 public class ReportProcessorFunctions
 {
     private readonly ILogger<ReportProcessorFunctions> _logger;
-    private readonly IConfiguration _configuration;
-    private const string TableName = "reportrequests";
-    private const string UserRequestsTableName = "userreportrequests";
-    private readonly TableClient _tableClient;
-    private readonly TableClient _userRequestsTableClient;
-    private readonly BlobServiceClient _serviceClient;
+    private readonly IReportStorageService _reportStorage;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
     private readonly ReportGenerator _reportGenerator;
     private readonly IReportCacheService _cacheService;
@@ -42,42 +33,18 @@ public class ReportProcessorFunctions
 
     public ReportProcessorFunctions(
         ILogger<ReportProcessorFunctions> logger,
-        IConfiguration configuration,
-        IRedditService redditService,
-        IGitHubService githubService,
-        IFeedbackAnalyzerService analyzerService,
+        IReportStorageService reportStorage,
+        ReportGenerator reportGenerator,
         IReportCacheService cacheService,
         IEmailService emailService,
         IUserAccountService userAccountService)
     {
-#if DEBUG
-        _configuration = new ConfigurationBuilder()
-                    .AddJsonFile("local.settings.json")
-                    .AddUserSecrets<Program>()
-                    .Build();
-#else
-        _configuration = configuration;
-#endif
         _logger = logger;
+        _reportStorage = reportStorage;
+        _reportGenerator = reportGenerator;
         _cacheService = cacheService;
         _emailService = emailService;
         _userAccountService = userAccountService;
-        
-        // Initialize table client
-        var storageConnection = _configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var tableServiceClient = new TableServiceClient(storageConnection);
-        _tableClient = tableServiceClient.GetTableClient(TableName);
-        _tableClient.CreateIfNotExists();
-        
-        // Initialize user requests table client
-        _userRequestsTableClient = tableServiceClient.GetTableClient(UserRequestsTableName);
-        _userRequestsTableClient.CreateIfNotExists();
-
-        // Initialize blob service client
-        _serviceClient = new BlobServiceClient(storageConnection);
-
-        // Initialize report generator
-        _reportGenerator = new ReportGenerator(_logger, redditService, githubService, analyzerService, _serviceClient, _configuration, _cacheService);
     }
 
     /// <summary>
@@ -463,7 +430,9 @@ public class ReportProcessorFunctions
         {
             var requests = new List<ReportRequestModel>();
             
-            await foreach (var entity in _tableClient.QueryAsync<ReportRequestModel>())
+            await _reportStorage.EnsureInitializedAsync();
+
+            await foreach (var entity in _reportStorage.ReportRequestsTable.QueryAsync<ReportRequestModel>())
             {
                 requests.Add(entity);
             }
@@ -523,7 +492,8 @@ public class ReportProcessorFunctions
             var limitParam = queryParams["limit"];
             var limit = int.TryParse(limitParam, out var parsedLimit) ? parsedLimit : 10;
 
-            var summaryContainerClient = _serviceClient.GetBlobContainerClient("weekly-summaries");
+            await _reportStorage.EnsureInitializedAsync();
+            var summaryContainerClient = _reportStorage.WeeklySummariesContainer;
             var summaries = new List<object>();
 
             await foreach (var blob in summaryContainerClient.GetBlobsAsync())
@@ -590,10 +560,8 @@ public class ReportProcessorFunctions
             var summaryJson = JsonSerializer.Serialize(summary, new JsonSerializerOptions { WriteIndented = true });
             var summaryFileName = $"weekly-summary-{DateTime.UtcNow:yyyy-MM-dd-HH-mm-ss}.json";
             
-            var summaryContainerClient = _serviceClient.GetBlobContainerClient("weekly-summaries");
-            await summaryContainerClient.CreateIfNotExistsAsync();
-            
-            var summaryBlobClient = summaryContainerClient.GetBlobClient(summaryFileName);
+            await _reportStorage.EnsureInitializedAsync();
+            var summaryBlobClient = _reportStorage.WeeklySummariesContainer.GetBlobClient(summaryFileName);
             await using var summaryStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(summaryJson));
             await summaryBlobClient.UploadAsync(summaryStream, overwrite: true);
 

--- a/feedbackfunctions/Reports/ReportRequestFunctions.cs
+++ b/feedbackfunctions/Reports/ReportRequestFunctions.cs
@@ -1,14 +1,9 @@
 using System.Net;
 using System.Text.Json;
+using Azure.Data.Tables;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
-using SharedDump.Models.Reports;
-using Azure.Data.Tables;
-using Azure.Storage.Blobs;
-using Microsoft.Extensions.Configuration;
-using SharedDump.Services.Interfaces;
-using SharedDump.AI;
 using FeedbackFunctions.Utils;
 using FeedbackFunctions.Services;
 using FeedbackFunctions.Services.Authentication;
@@ -19,6 +14,8 @@ using FeedbackFunctions.Services.Account;
 using SharedDump.Services;
 using SharedDump.Models.Account;
 using FeedbackFunctions.Services.Reports;
+using SharedDump.Models.Reports;
+using SharedDump.Services.Interfaces;
 
 namespace FeedbackFunctions;
 
@@ -28,12 +25,7 @@ namespace FeedbackFunctions;
 public class ReportRequestFunctions
 {
     private readonly ILogger<ReportRequestFunctions> _logger;
-    private readonly IConfiguration _configuration;
-    private const string TableName = "reportrequests";
-    private const string UserRequestsTableName = "userreportrequests";
-    private readonly TableClient _tableClient;
-    private readonly TableClient _userRequestsTableClient;
-    private readonly BlobServiceClient _serviceClient; // Still needed for reports filtering
+    private readonly IReportStorageService _reportStorage;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
     private readonly ReportGenerator _reportGenerator;
     private readonly IReportCacheService _cacheService;
@@ -44,44 +36,22 @@ public class ReportRequestFunctions
 
     public ReportRequestFunctions(
         ILogger<ReportRequestFunctions> logger,
-        IConfiguration configuration,
+        IReportStorageService reportStorage,
+        ReportGenerator reportGenerator,
         IRedditService redditService,
         IGitHubService githubService,
-        IFeedbackAnalyzerService analyzerService,
         IReportCacheService cacheService,
         FeedbackFunctions.Middleware.AuthenticationMiddleware authMiddleware,
         IUserAccountService userAccountService)
     {
-#if DEBUG
-        _configuration = new ConfigurationBuilder()
-                    .AddJsonFile("local.settings.json")
-                    .AddUserSecrets<Program>()
-                    .Build();
-#else
-        _configuration = configuration;
-#endif
         _logger = logger;
+        _reportStorage = reportStorage;
+        _reportGenerator = reportGenerator;
         _cacheService = cacheService;
         _redditService = redditService;
         _githubService = githubService;
         _authMiddleware = authMiddleware;
         _userAccountService = userAccountService;
-        
-        // Initialize table client
-        var storageConnection = _configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var tableServiceClient = new TableServiceClient(storageConnection);
-        _tableClient = tableServiceClient.GetTableClient(TableName);
-        _tableClient.CreateIfNotExists();
-
-        // Initialize user-specific requests table client
-        _userRequestsTableClient = tableServiceClient.GetTableClient(UserRequestsTableName);
-        _userRequestsTableClient.CreateIfNotExists();
-
-        // Initialize blob service client for reports filtering
-        _serviceClient = new BlobServiceClient(storageConnection);
-
-        // Initialize report generator
-        _reportGenerator = new ReportGenerator(_logger, redditService, githubService, analyzerService, _serviceClient, _configuration, _cacheService);
     }
 
     private static string GenerateRequestId(ReportRequestModel request)
@@ -282,7 +252,9 @@ public class ReportRequestFunctions
             try
             {
                 // Check if this user already has this request
-                var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
+                await _reportStorage.EnsureInitializedAsync();
+
+                var existingEntities = _reportStorage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(
                     filter: $"PartitionKey eq '{request.PartitionKey}' and RowKey eq '{request.RowKey}'",
                     maxPerPage: 1);
 
@@ -301,7 +273,7 @@ public class ReportRequestFunctions
                 }
 
                 // Add the user request
-                await _userRequestsTableClient.AddEntityAsync(request);
+                await _reportStorage.UserReportRequestsTable.AddEntityAsync(request);
                 
                 _logger.LogInformation("Created new user report request {RequestId} for user {UserId}, {Type}: {Details}", 
                     request.Id, request.UserId, request.Type, 
@@ -322,7 +294,7 @@ public class ReportRequestFunctions
                 globalRequest.RowKey = globalRequestId;
 
                 // Check if global request exists and increment subscriber count
-                var globalExistingEntities = _tableClient.QueryAsync<ReportRequestModel>(
+                var globalExistingEntities = _reportStorage.ReportRequestsTable.QueryAsync<ReportRequestModel>(
                     filter: $"PartitionKey eq '{globalRequest.PartitionKey}' and RowKey eq '{globalRequest.RowKey}'",
                     maxPerPage: 1);
 
@@ -336,11 +308,11 @@ public class ReportRequestFunctions
                 if (globalExistingEntity != null)
                 {
                     globalExistingEntity.SubscriberCount++;
-                    await _tableClient.UpdateEntityAsync(globalExistingEntity, globalExistingEntity.ETag);
+                    await _reportStorage.ReportRequestsTable.UpdateEntityAsync(globalExistingEntity, globalExistingEntity.ETag);
                 }
                 else
                 {
-                    await _tableClient.AddEntityAsync(globalRequest);
+                    await _reportStorage.ReportRequestsTable.AddEntityAsync(globalRequest);
                     
                     // Start report generation in the background
                     _ = Task.Run(async () =>
@@ -432,7 +404,9 @@ public class ReportRequestFunctions
             try
             {
                 // Check if user request exists
-                var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
+                await _reportStorage.EnsureInitializedAsync();
+
+                var existingEntities = _reportStorage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(
                     filter: $"PartitionKey eq '{partitionKey}' and RowKey eq '{rowKey}'",
                     maxPerPage: 1);
 
@@ -451,7 +425,7 @@ public class ReportRequestFunctions
                 }
 
                 // Remove the user request
-                await _userRequestsTableClient.DeleteEntityAsync(partitionKey, rowKey);
+                await _reportStorage.UserReportRequestsTable.DeleteEntityAsync(partitionKey, rowKey);
                 
                 // Also decrement global request subscriber count
                 var globalRequest = new ReportRequestModel
@@ -465,7 +439,7 @@ public class ReportRequestFunctions
                 var globalRequestId = GenerateRequestId(globalRequest);
                 var globalPartitionKey = globalRequest.Type.ToLowerInvariant();
 
-                var globalExistingEntities = _tableClient.QueryAsync<ReportRequestModel>(
+                var globalExistingEntities = _reportStorage.ReportRequestsTable.QueryAsync<ReportRequestModel>(
                     filter: $"PartitionKey eq '{globalPartitionKey}' and RowKey eq '{globalRequestId}'",
                     maxPerPage: 1);
 
@@ -481,11 +455,11 @@ public class ReportRequestFunctions
                     if (globalExistingEntity.SubscriberCount > 1)
                     {
                         globalExistingEntity.SubscriberCount--;
-                        await _tableClient.UpdateEntityAsync(globalExistingEntity, globalExistingEntity.ETag);
+                        await _reportStorage.ReportRequestsTable.UpdateEntityAsync(globalExistingEntity, globalExistingEntity.ETag);
                     }
                     else
                     {
-                        await _tableClient.DeleteEntityAsync(globalPartitionKey, globalRequestId);
+                        await _reportStorage.ReportRequestsTable.DeleteEntityAsync(globalPartitionKey, globalRequestId);
                     }
                 }
                 
@@ -561,7 +535,9 @@ public class ReportRequestFunctions
             var rowKey = id;
 
             // Check if user request exists
-            var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
+            await _reportStorage.EnsureInitializedAsync();
+
+            var existingEntities = _reportStorage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(
                 filter: $"PartitionKey eq '{partitionKey}' and RowKey eq '{rowKey}'",
                 maxPerPage: 1);
 
@@ -601,7 +577,7 @@ public class ReportRequestFunctions
             existingEntity.EmailEnabled = emailEnabled;
 
             // Update the entity in table storage
-            await _userRequestsTableClient.UpdateEntityAsync(existingEntity, existingEntity.ETag);
+            await _reportStorage.UserReportRequestsTable.UpdateEntityAsync(existingEntity, existingEntity.ETag);
             
             _logger.LogInformation("Updated email settings for user report request {RequestId} for user {UserId}: EmailEnabled={EmailEnabled}", 
                 id, user.UserId, emailEnabled);
@@ -659,7 +635,9 @@ public class ReportRequestFunctions
             var requests = new List<UserReportRequestModel>();
             
             // Query for this user's requests
-            await foreach (var entity in _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
+            await _reportStorage.EnsureInitializedAsync();
+
+            await foreach (var entity in _reportStorage.UserReportRequestsTable.QueryAsync<UserReportRequestModel>(
                 filter: $"PartitionKey eq '{user.UserId}'"))
             {
                 requests.Add(entity);

--- a/feedbackfunctions/Services/Account/ApiKeyService.cs
+++ b/feedbackfunctions/Services/Account/ApiKeyService.cs
@@ -1,8 +1,12 @@
 using System.Security.Cryptography;
 using System.Text;
+
 using Azure.Data.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+
+using FeedbackFunctions.Services.Storage;
+
 using SharedDump.Models.Account;
 
 namespace FeedbackFunctions.Services.Account;
@@ -11,20 +15,23 @@ public class ApiKeyService : IApiKeyService
 {
     private readonly ILogger<ApiKeyService> _logger;
     private readonly TableClient _tableClient;
+    private readonly ITableInitializationService _tableInitializationService;
     private const string TableName = "apikeys";
 
-    public ApiKeyService(ILogger<ApiKeyService> logger, IConfiguration configuration)
+    public ApiKeyService(
+        ILogger<ApiKeyService> logger,
+        FeedbackStorageClients storageClients,
+        ITableInitializationService tableInitializationService)
     {
         _logger = logger;
-        
-        var connectionString = configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var tableServiceClient = new TableServiceClient(connectionString);
-        _tableClient = tableServiceClient.GetTableClient(TableName);
-        _tableClient.CreateIfNotExists();
+        _tableClient = storageClients.ApiKeysTable;
+        _tableInitializationService = tableInitializationService;
     }
 
     public async Task<ApiKey?> GetApiKeyByUserIdAsync(string userId)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var filter = $"UserId eq '{userId}'";
@@ -43,6 +50,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task<ApiKey?> GetApiKeyByKeyAsync(string apiKey)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var response = await _tableClient.GetEntityIfExistsAsync<ApiKeyEntity>("apikeys", apiKey);
@@ -71,6 +80,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task<ApiKey> CreateApiKeyAsync(string userId, string? name = null)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             // Check if user already has an API key
@@ -107,6 +118,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task<bool> DeleteApiKeyAsync(string userId)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var existingKey = await GetApiKeyByUserIdAsync(userId);
@@ -142,6 +155,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task UpdateLastUsedAsync(string apiKey)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var entity = await _tableClient.GetEntityIfExistsAsync<ApiKeyEntity>("apikeys", apiKey);
@@ -160,6 +175,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task<List<ApiKey>> GetAllApiKeysAsync()
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var apiKeys = new List<ApiKey>();
@@ -182,6 +199,8 @@ public class ApiKeyService : IApiKeyService
 
     public async Task<bool> UpdateApiKeyStatusAsync(string apiKey, bool isEnabled)
     {
+        await _tableInitializationService.EnsureAccountTablesAsync();
+
         try
         {
             var entity = await _tableClient.GetEntityIfExistsAsync<ApiKeyEntity>("apikeys", apiKey);

--- a/feedbackfunctions/Services/Account/UserAccountService.cs
+++ b/feedbackfunctions/Services/Account/UserAccountService.cs
@@ -2,9 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Azure.Data.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+
+using FeedbackFunctions.Services.Storage;
+
 using SharedDump.Models.Account;
 using SharedDump.Models.Admin;
 
@@ -15,6 +19,7 @@ public class UserAccountService : IUserAccountService
     private readonly TableClient _userAccountsTable;
     private readonly TableClient _usageRecordsTable;
     private readonly TableClient _apiKeysTable;
+    private readonly ITableInitializationService? _tableInitializationService;
     private readonly IConfiguration? _configuration;
     private readonly ILogger<UserAccountService>? _logger;
 
@@ -23,10 +28,28 @@ public class UserAccountService : IUserAccountService
     private const string ApiKeysTableName = "apikeys";
 
     public UserAccountService(string storageConnectionString, IConfiguration? configuration = null, ILogger<UserAccountService>? logger = null)
+        : this(
+            new TableClient(storageConnectionString, UserAccountsTableName),
+            new TableClient(storageConnectionString, UsageRecordsTableName),
+            new TableClient(storageConnectionString, ApiKeysTableName),
+            null,
+            configuration,
+            logger)
     {
-        _userAccountsTable = new TableClient(storageConnectionString, UserAccountsTableName);
-        _usageRecordsTable = new TableClient(storageConnectionString, UsageRecordsTableName);
-        _apiKeysTable = new TableClient(storageConnectionString, ApiKeysTableName);
+    }
+
+    public UserAccountService(
+        TableClient userAccountsTable,
+        TableClient usageRecordsTable,
+        TableClient apiKeysTable,
+        ITableInitializationService? tableInitializationService = null,
+        IConfiguration? configuration = null,
+        ILogger<UserAccountService>? logger = null)
+    {
+        _userAccountsTable = userAccountsTable;
+        _usageRecordsTable = usageRecordsTable;
+        _apiKeysTable = apiKeysTable;
+        _tableInitializationService = tableInitializationService;
         _configuration = configuration;
         _logger = logger;
     }
@@ -35,6 +58,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task<UserAccount?> GetUserAccountAsync(string userId)
     {
+        await EnsureTablesInitializedAsync();
+
         try
         {
             var response = await _userAccountsTable.GetEntityIfExistsAsync<UserAccountEntity>(userId, "account");
@@ -51,6 +76,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task UpsertUserAccountAsync(UserAccount userAccount)
     {
+        await EnsureTablesInitializedAsync();
+
         var entity = MapModelToEntity(userAccount);
         await _userAccountsTable.UpsertEntityAsync(entity);
     }
@@ -58,6 +85,8 @@ public class UserAccountService : IUserAccountService
     /// <inheritdoc />
     public async Task<UserAccount> CreateUserAccountIfNotExistsAsync(UserAccount userAccount, string? preferredEmailOverride = null)
     {
+        await EnsureTablesInitializedAsync();
+
         // Attempt fast path read
         var existing = await _userAccountsTable.GetEntityIfExistsAsync<UserAccountEntity>(userAccount.UserId, "account");
         if (existing.HasValue)
@@ -140,6 +169,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task<bool> DeleteUserAccountAsync(string userId)
     {
+        await EnsureTablesInitializedAsync();
+
         try
         {
             var entity = await _userAccountsTable.GetEntityIfExistsAsync<UserAccountEntity>(userId, "account");
@@ -175,6 +206,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task<Dictionary<string, SharedDump.Models.Account.AccountTier>> GetAllUserTiersAsync()
     {
+        await EnsureTablesInitializedAsync();
+
         var userTiers = new Dictionary<string, SharedDump.Models.Account.AccountTier>(StringComparer.OrdinalIgnoreCase);
         try
         {
@@ -196,6 +229,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task<int> ResetAllMonthlyUsageAsync()
     {
+        await EnsureTablesInitializedAsync();
+
         var resetCount = 0;
         var resetDate = DateTime.UtcNow;
 
@@ -329,6 +364,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task TrackUsageAsync(string userId, UsageType usageType, string? resourceId = null, int amount = 1)
     {
+        await EnsureTablesInitializedAsync();
+
         var user = await GetUserAccountAsync(userId);
         
         // If user account doesn't exist, they haven't registered yet - don't track usage
@@ -384,6 +421,8 @@ public class UserAccountService : IUserAccountService
 
     public async Task<List<UsageRecord>> GetUsageHistoryAsync(string userId)
     {
+        await EnsureTablesInitializedAsync();
+
         var results = new List<UsageRecord>();
         
         try
@@ -438,14 +477,15 @@ public class UserAccountService : IUserAccountService
 
     public async Task InitializeTablesAsync()
     {
-        await _userAccountsTable.CreateIfNotExistsAsync();
-        await _usageRecordsTable.CreateIfNotExistsAsync();
-        await _apiKeysTable.CreateIfNotExistsAsync();
+        await EnsureTablesInitializedAsync();
     }
 
     #endregion
 
     #region Private Helper Methods
+
+    private Task EnsureTablesInitializedAsync() =>
+        _tableInitializationService?.EnsureAccountTablesAsync() ?? Task.CompletedTask;
 
     private int GetConfigValue(string key, int defaultValue)
     {

--- a/feedbackfunctions/Services/Authentication/AuthUserTableService.cs
+++ b/feedbackfunctions/Services/Authentication/AuthUserTableService.cs
@@ -1,6 +1,9 @@
 using Azure.Data.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+
+using FeedbackFunctions.Services.Storage;
+
 using SharedDump.Models.Authentication;
 
 namespace FeedbackFunctions.Services.Authentication;
@@ -10,8 +13,8 @@ namespace FeedbackFunctions.Services.Authentication;
 /// </summary>
 public class AuthUserTableService : IAuthUserTableService
 {
-    private readonly TableServiceClient _tableServiceClient;
     private readonly TableClient _userTableClient;
+    private readonly ITableInitializationService _tableInitializationService;
     private readonly ILogger<AuthUserTableService> _logger;
     private const string AUTH_USERS_TABLE = "AuthUsers";
 
@@ -20,25 +23,21 @@ public class AuthUserTableService : IAuthUserTableService
     /// </summary>
     /// <param name="configuration">Configuration for connection string</param>
     /// <param name="logger">Logger for diagnostic information</param>
-    public AuthUserTableService(IConfiguration configuration, ILogger<AuthUserTableService> logger)
+    public AuthUserTableService(
+        FeedbackStorageClients storageClients,
+        ITableInitializationService tableInitializationService,
+        ILogger<AuthUserTableService> logger)
     {
-        var connectionString = configuration["ProductionStorage"] ??
-                             throw new InvalidOperationException("No storage connection string configured");
-
-        _tableServiceClient = new TableServiceClient(connectionString);
-        _userTableClient = _tableServiceClient.GetTableClient(AUTH_USERS_TABLE);
+        _userTableClient = storageClients.AuthUsersTable;
+        _tableInitializationService = tableInitializationService;
         _logger = logger;
-
-        // Ensure tables exist
-        _ = Task.Run(async () =>
-        {
-            await _userTableClient.CreateIfNotExistsAsync();
-        });
     }
 
     /// <inheritdoc />
     public async Task<AuthUserEntity?> GetUserByProviderAsync(string provider, string providerUserId)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             var response = await _userTableClient.GetEntityIfExistsAsync<AuthUserEntity>(provider, providerUserId);
@@ -54,6 +53,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<AuthUserEntity?> GetUserByEmailAsync(string email)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             // Direct query across all partitions - this is more expensive but simpler
@@ -74,6 +75,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<AuthUserEntity?> GetUserByIdAsync(string userId)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             // This requires a cross-partition query, which is more expensive
@@ -94,6 +97,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<AuthUserEntity> CreateOrUpdateUserAsync(AuthUserEntity user)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             var existing = await GetUserByProviderAsync(user.AuthProvider, user.ProviderUserId);
@@ -114,6 +119,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<AuthUserEntity> CreateUserIfNotExistsAsync(AuthUserEntity user)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             // First try to add the entity atomically - this will fail if it already exists
@@ -175,6 +182,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<bool> DeleteUserAsync(string userId)
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         try
         {
             var user = await GetUserByIdAsync(userId);
@@ -195,6 +204,8 @@ public class AuthUserTableService : IAuthUserTableService
     /// <inheritdoc />
     public async Task<IEnumerable<AuthUserEntity>> GetAllUsersAsync()
     {
+        await _tableInitializationService.EnsureAuthTablesAsync();
+
         var users = new List<AuthUserEntity>();
         try
         {

--- a/feedbackfunctions/Services/Reports/AdminReportConfigService.cs
+++ b/feedbackfunctions/Services/Reports/AdminReportConfigService.cs
@@ -1,6 +1,9 @@
 using Azure.Data.Tables;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+
+using FeedbackFunctions.Services.Storage;
+
 using SharedDump.Models.Reports;
 
 namespace FeedbackFunctions.Services.Reports;
@@ -8,33 +11,24 @@ namespace FeedbackFunctions.Services.Reports;
 public class AdminReportConfigService : IAdminReportConfigService
 {
     private readonly TableClient _tableClient;
+    private readonly ITableInitializationService _tableInitializationService;
     private readonly ILogger<AdminReportConfigService> _logger;
     private const string TableName = "AdminReportConfigs";
 
-    public AdminReportConfigService(IConfiguration configuration, ILogger<AdminReportConfigService> logger)
+    public AdminReportConfigService(
+        FeedbackStorageClients storageClients,
+        ITableInitializationService tableInitializationService,
+        ILogger<AdminReportConfigService> logger)
     {
         _logger = logger;
-        var connectionString = configuration["ProductionStorage"] ??
-                             throw new InvalidOperationException("ProductionStorage connection string not found");
-        
-        _tableClient = new TableClient(connectionString, TableName);
-        
-        // Ensure table exists
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await _tableClient.CreateIfNotExistsAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Could not ensure table {TableName} exists", TableName);
-            }
-        });
+        _tableClient = storageClients.AdminReportConfigsTable;
+        _tableInitializationService = tableInitializationService;
     }
 
     public async Task<List<AdminReportConfigModel>> GetAllActiveConfigsAsync()
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             var configs = new List<AdminReportConfigModel>();
@@ -53,6 +47,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task<List<AdminReportConfigModel>> GetAllConfigsAsync()
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             var configs = new List<AdminReportConfigModel>();
@@ -71,6 +67,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task<AdminReportConfigModel?> GetConfigAsync(string id)
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             var response = await _tableClient.GetEntityIfExistsAsync<AdminReportConfigModel>("AdminReports", id);
@@ -85,6 +83,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task<AdminReportConfigModel> CreateConfigAsync(AdminReportConfigModel config)
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             // Generate ID if not provided
@@ -111,6 +111,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task<AdminReportConfigModel> UpdateConfigAsync(AdminReportConfigModel config)
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             // Ensure partition key and row key are set
@@ -131,6 +133,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task<bool> DeleteConfigAsync(string id)
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             // Get the entity first to ensure it exists and get the ETag
@@ -154,6 +158,8 @@ public class AdminReportConfigService : IAdminReportConfigService
 
     public async Task MarkConfigProcessedAsync(string id, DateTimeOffset processedAt)
     {
+        await _tableInitializationService.EnsureAdminReportConfigsAsync();
+
         try
         {
             var config = await GetConfigAsync(id);

--- a/feedbackfunctions/Services/Reports/IReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/IReportStorageService.cs
@@ -1,0 +1,19 @@
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+
+namespace FeedbackFunctions.Services.Reports;
+
+public interface IReportStorageService
+{
+    BlobContainerClient ReportsContainer { get; }
+
+    BlobContainerClient ReportsSummaryContainer { get; }
+
+    BlobContainerClient WeeklySummariesContainer { get; }
+
+    TableClient ReportRequestsTable { get; }
+
+    TableClient UserReportRequestsTable { get; }
+
+    Task EnsureInitializedAsync();
+}

--- a/feedbackfunctions/Services/Reports/ReportCacheService.cs
+++ b/feedbackfunctions/Services/Reports/ReportCacheService.cs
@@ -14,6 +14,7 @@ public class ReportCacheService : IReportCacheService
 {
     private readonly ILogger<ReportCacheService> _logger;
     private readonly BlobContainerClient _containerClient;
+    private readonly IReportStorageService? _reportStorage;
     private readonly ConcurrentDictionary<string, CachedReport> _cache = new();
     private readonly SemaphoreSlim _refreshSemaphore = new(1, 1);
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -26,16 +27,21 @@ public class ReportCacheService : IReportCacheService
     /// </summary>
     /// <param name="logger">Logger instance</param>
     /// <param name="containerClient">Blob container client for reports</param>
-    public ReportCacheService(ILogger<ReportCacheService> logger, BlobContainerClient containerClient)
+    public ReportCacheService(
+        ILogger<ReportCacheService> logger,
+        BlobContainerClient containerClient,
+        IReportStorageService? reportStorage = null)
     {
         _logger = logger;
         _containerClient = containerClient;
+        _reportStorage = reportStorage;
     }
 
     /// <inheritdoc />
     public async Task<ReportModel?> GetReportAsync(string reportId)
     {
         var stopwatch = Stopwatch.StartNew();
+        await EnsureStorageInitializedAsync();
         await EnsureCacheIsValidAsync();
 
         if (_cache.TryGetValue(reportId, out var cachedReport))
@@ -92,6 +98,7 @@ public class ReportCacheService : IReportCacheService
     /// <inheritdoc />
     public async Task<List<ReportModel>> GetReportsAsync(string? sourceFilter = null, string? subsourceFilter = null)
     {
+        await EnsureStorageInitializedAsync();
         await EnsureCacheIsValidAsync();
 
         var reports = _cache.Values
@@ -159,6 +166,7 @@ public class ReportCacheService : IReportCacheService
     public async Task RefreshCacheAsync()
     {
         var stopwatch = Stopwatch.StartNew();
+        await EnsureStorageInitializedAsync();
         await _refreshSemaphore.WaitAsync();
         try
         {
@@ -242,6 +250,9 @@ public class ReportCacheService : IReportCacheService
                 stopwatch.ElapsedMilliseconds);
         }
     }
+
+    private Task EnsureStorageInitializedAsync() =>
+        _reportStorage?.EnsureInitializedAsync() ?? Task.CompletedTask;
 
     /// <summary>
     /// Represents a cached report with timestamp

--- a/feedbackfunctions/Services/Reports/ReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/ReportStorageService.cs
@@ -1,0 +1,32 @@
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+
+using FeedbackFunctions.Services.Storage;
+
+namespace FeedbackFunctions.Services.Reports;
+
+public class ReportStorageService : IReportStorageService
+{
+    private readonly FeedbackStorageClients _storage;
+    private readonly ITableInitializationService _tableInitializationService;
+
+    public ReportStorageService(
+        FeedbackStorageClients storage,
+        ITableInitializationService tableInitializationService)
+    {
+        _storage = storage;
+        _tableInitializationService = tableInitializationService;
+    }
+
+    public BlobContainerClient ReportsContainer => _storage.ReportsContainer;
+
+    public BlobContainerClient ReportsSummaryContainer => _storage.ReportsSummaryContainer;
+
+    public BlobContainerClient WeeklySummariesContainer => _storage.WeeklySummariesContainer;
+
+    public TableClient ReportRequestsTable => _storage.ReportRequestsTable;
+
+    public TableClient UserReportRequestsTable => _storage.UserReportRequestsTable;
+
+    public Task EnsureInitializedAsync() => _tableInitializationService.EnsureReportStorageAsync();
+}

--- a/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
+++ b/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
@@ -1,0 +1,88 @@
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+
+namespace FeedbackFunctions.Services.Storage;
+
+public class FeedbackStorageClients
+{
+    public FeedbackStorageClients(
+        BlobServiceClient blobServiceClient,
+        TableServiceClient tableServiceClient)
+        : this(
+            blobServiceClient,
+            tableServiceClient,
+            blobServiceClient.GetBlobContainerClient(StorageNames.ReportsContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.ReportsSummaryContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.WeeklySummariesContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.SharedAnalysesContainer),
+            tableServiceClient.GetTableClient(StorageNames.UserAccountsTable),
+            tableServiceClient.GetTableClient(StorageNames.UsageRecordsTable),
+            tableServiceClient.GetTableClient(StorageNames.ApiKeysTable),
+            tableServiceClient.GetTableClient(StorageNames.AuthUsersTable),
+            tableServiceClient.GetTableClient(StorageNames.ReportRequestsTable),
+            tableServiceClient.GetTableClient(StorageNames.UserReportRequestsTable),
+            tableServiceClient.GetTableClient(StorageNames.AdminReportConfigsTable),
+            tableServiceClient.GetTableClient(StorageNames.SharedAnalysesTable))
+    {
+    }
+
+    public FeedbackStorageClients(
+        BlobServiceClient? blobServiceClient,
+        TableServiceClient? tableServiceClient,
+        BlobContainerClient reportsContainer,
+        BlobContainerClient reportsSummaryContainer,
+        BlobContainerClient weeklySummariesContainer,
+        BlobContainerClient sharedAnalysesContainer,
+        TableClient userAccountsTable,
+        TableClient usageRecordsTable,
+        TableClient apiKeysTable,
+        TableClient authUsersTable,
+        TableClient reportRequestsTable,
+        TableClient userReportRequestsTable,
+        TableClient adminReportConfigsTable,
+        TableClient sharedAnalysesTable)
+    {
+        BlobServiceClient = blobServiceClient;
+        TableServiceClient = tableServiceClient;
+        ReportsContainer = reportsContainer;
+        ReportsSummaryContainer = reportsSummaryContainer;
+        WeeklySummariesContainer = weeklySummariesContainer;
+        SharedAnalysesContainer = sharedAnalysesContainer;
+        UserAccountsTable = userAccountsTable;
+        UsageRecordsTable = usageRecordsTable;
+        ApiKeysTable = apiKeysTable;
+        AuthUsersTable = authUsersTable;
+        ReportRequestsTable = reportRequestsTable;
+        UserReportRequestsTable = userReportRequestsTable;
+        AdminReportConfigsTable = adminReportConfigsTable;
+        SharedAnalysesTable = sharedAnalysesTable;
+    }
+
+    public BlobServiceClient? BlobServiceClient { get; }
+
+    public TableServiceClient? TableServiceClient { get; }
+
+    public BlobContainerClient ReportsContainer { get; }
+
+    public BlobContainerClient ReportsSummaryContainer { get; }
+
+    public BlobContainerClient WeeklySummariesContainer { get; }
+
+    public BlobContainerClient SharedAnalysesContainer { get; }
+
+    public TableClient UserAccountsTable { get; }
+
+    public TableClient UsageRecordsTable { get; }
+
+    public TableClient ApiKeysTable { get; }
+
+    public TableClient AuthUsersTable { get; }
+
+    public TableClient ReportRequestsTable { get; }
+
+    public TableClient UserReportRequestsTable { get; }
+
+    public TableClient AdminReportConfigsTable { get; }
+
+    public TableClient SharedAnalysesTable { get; }
+}

--- a/feedbackfunctions/Services/Storage/ITableInitializationService.cs
+++ b/feedbackfunctions/Services/Storage/ITableInitializationService.cs
@@ -1,0 +1,14 @@
+namespace FeedbackFunctions.Services.Storage;
+
+public interface ITableInitializationService
+{
+    Task EnsureAccountTablesAsync();
+
+    Task EnsureAuthTablesAsync();
+
+    Task EnsureReportStorageAsync();
+
+    Task EnsureAdminReportConfigsAsync();
+
+    Task EnsureSharedAnalysesStorageAsync();
+}

--- a/feedbackfunctions/Services/Storage/StorageNames.cs
+++ b/feedbackfunctions/Services/Storage/StorageNames.cs
@@ -1,0 +1,18 @@
+namespace FeedbackFunctions.Services.Storage;
+
+public static class StorageNames
+{
+    public const string ReportsContainer = "reports";
+    public const string ReportsSummaryContainer = "reports-summary";
+    public const string WeeklySummariesContainer = "weekly-summaries";
+    public const string SharedAnalysesContainer = "shared-analyses";
+
+    public const string UserAccountsTable = "UserAccounts";
+    public const string UsageRecordsTable = "UsageRecords";
+    public const string ApiKeysTable = "apikeys";
+    public const string AuthUsersTable = "AuthUsers";
+    public const string ReportRequestsTable = "reportrequests";
+    public const string UserReportRequestsTable = "userreportrequests";
+    public const string AdminReportConfigsTable = "AdminReportConfigs";
+    public const string SharedAnalysesTable = "SharedAnalyses";
+}

--- a/feedbackfunctions/Services/Storage/TableInitializationService.cs
+++ b/feedbackfunctions/Services/Storage/TableInitializationService.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+using Microsoft.Extensions.Logging;
+
+namespace FeedbackFunctions.Services.Storage;
+
+public class TableInitializationService : ITableInitializationService
+{
+    private readonly FeedbackStorageClients _storage;
+    private readonly ILogger<TableInitializationService> _logger;
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _initializers = new(StringComparer.OrdinalIgnoreCase);
+
+    public TableInitializationService(
+        FeedbackStorageClients storage,
+        ILogger<TableInitializationService> logger)
+    {
+        _storage = storage;
+        _logger = logger;
+    }
+
+    public Task EnsureAccountTablesAsync() =>
+        EnsureAsync("accounts", async () =>
+        {
+            await Task.WhenAll(
+                _storage.UserAccountsTable.CreateIfNotExistsAsync(),
+                _storage.UsageRecordsTable.CreateIfNotExistsAsync(),
+                _storage.ApiKeysTable.CreateIfNotExistsAsync());
+        });
+
+    public Task EnsureAuthTablesAsync() =>
+        EnsureAsync("auth", () => _storage.AuthUsersTable.CreateIfNotExistsAsync());
+
+    public Task EnsureReportStorageAsync() =>
+        EnsureAsync("reports", async () =>
+        {
+            await Task.WhenAll(
+                _storage.ReportRequestsTable.CreateIfNotExistsAsync(),
+                _storage.UserReportRequestsTable.CreateIfNotExistsAsync(),
+                _storage.ReportsContainer.CreateIfNotExistsAsync(),
+                _storage.ReportsSummaryContainer.CreateIfNotExistsAsync(),
+                _storage.WeeklySummariesContainer.CreateIfNotExistsAsync());
+        });
+
+    public Task EnsureAdminReportConfigsAsync() =>
+        EnsureAsync("admin-report-configs", () => _storage.AdminReportConfigsTable.CreateIfNotExistsAsync());
+
+    public Task EnsureSharedAnalysesStorageAsync() =>
+        EnsureAsync("shared-analyses", async () =>
+        {
+            await Task.WhenAll(
+                _storage.SharedAnalysesTable.CreateIfNotExistsAsync(),
+                _storage.SharedAnalysesContainer.CreateIfNotExistsAsync());
+        });
+
+    private Task EnsureAsync(string key, Func<Task> initialize) =>
+        _initializers.GetOrAdd(
+            key,
+            _ => new Lazy<Task>(
+                async () =>
+                {
+                    _logger.LogInformation("Initializing storage scope {Scope}", key);
+                    await initialize();
+                },
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+}

--- a/feedbackfunctions/Sharing/SharingFunctions.cs
+++ b/feedbackfunctions/Sharing/SharingFunctions.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
+using FeedbackFunctions.Services.Storage;
 
 namespace FeedbackFunctions;
 
@@ -58,7 +59,8 @@ public class SharingFunctions
     private const string TableName = "SharedAnalyses";
     private readonly ILogger<SharingFunctions> _logger;
     private readonly AuthenticationMiddleware _authMiddleware;
-    private readonly TableClient _tableClient;
+    private readonly FeedbackStorageClients _storage;
+    private readonly ITableInitializationService _tableInitializationService;
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _sharedAnalysisCache = new();
 
     /// <summary>
@@ -70,17 +72,15 @@ public class SharingFunctions
     public SharingFunctions(
         ILogger<SharingFunctions> logger,
         AuthenticationMiddleware authMiddleware,
-        IConfiguration configuration,
+        FeedbackStorageClients storage,
+        ITableInitializationService tableInitializationService,
         FeedbackFunctions.Services.Account.IUserAccountService userAccountService)
     {
         _logger = logger;
         _authMiddleware = authMiddleware;
+        _storage = storage;
+        _tableInitializationService = tableInitializationService;
         _userAccountService = userAccountService;
-        // Initialize table client
-        var storageConnection = configuration["ProductionStorage"] ?? throw new InvalidOperationException("Production storage connection string not configured");
-        var tableServiceClient = new TableServiceClient(storageConnection);
-        _tableClient = tableServiceClient.GetTableClient(TableName);
-        _tableClient.CreateIfNotExists();
     }
 
 
@@ -147,6 +147,8 @@ public class SharingFunctions
         
         try
         {
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
             // Save to blob storage with the ID as the blob name
             var blobClient = containerClient.GetBlobClient($"{id}.json");
             
@@ -157,7 +159,7 @@ public class SharingFunctions
 
             // Save metadata to table storage with public flag
             var sharedAnalysisEntity = new SharedAnalysisEntity(user.UserId, id, analysisData, isPublic);
-            await _tableClient.UpsertEntityAsync(sharedAnalysisEntity);
+            await _storage.SharedAnalysesTable.UpsertEntityAsync(sharedAnalysisEntity);
 
             // Add to in-memory cache
             _sharedAnalysisCache[id] = analysisJson;
@@ -198,9 +200,11 @@ public class SharingFunctions
         SharedAnalysisEntity? analysisEntity = null;
         try
         {
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
             _logger.LogDebug("Querying table storage for analysis with RowKey: {Id}", id);
             // Try to find the entity by scanning all partitions (since we don't know the user ID)
-            await foreach (var entity in _tableClient.QueryAsync<SharedAnalysisEntity>(
+            await foreach (var entity in _storage.SharedAnalysesTable.QueryAsync<SharedAnalysisEntity>(
                 filter: $"RowKey eq '{id}'"))
             {
                 _logger.LogDebug("Found entity in table storage: UserId={UserId}, IsPublic={IsPublic}",
@@ -332,6 +336,8 @@ public class SharingFunctions
 
         try
         {
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
             // Parse request body to get new visibility setting
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
             var visibilityRequest = JsonSerializer.Deserialize<UpdateVisibilityRequest>(requestBody, 
@@ -345,7 +351,7 @@ public class SharingFunctions
             }
 
             // Check if the analysis exists and belongs to the user
-            var existingEntity = await _tableClient.GetEntityIfExistsAsync<SharedAnalysisEntity>(user.UserId, id);
+            var existingEntity = await _storage.SharedAnalysesTable.GetEntityIfExistsAsync<SharedAnalysisEntity>(user.UserId, id);
             
             if (!existingEntity.HasValue)
             {
@@ -369,7 +375,7 @@ public class SharingFunctions
             entity.PublicSharedDate = isPublic ? DateTime.UtcNow : null;
 
             // Save updated entity
-            await _tableClient.UpsertEntityAsync(entity);
+            await _storage.SharedAnalysesTable.UpsertEntityAsync(entity);
 
             // Remove from cache to ensure fresh data is loaded with updated visibility settings
             _sharedAnalysisCache.TryRemove(id, out _);
@@ -404,6 +410,7 @@ public class SharingFunctions
         [BlobInput(ContainerName, Connection = "ProductionStorage")] BlobContainerClient containerClient)
     {
         _logger.LogInformation($"Starting cleanup of old analyses at: {DateTime.UtcNow}");
+        await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
 
         var deletedBlobCount = 0;
         var deletedTableCount = 0;
@@ -427,7 +434,7 @@ public class SharingFunctions
             SharedAnalysisEntity? entity = null;
             try
             {
-                await foreach (var e in _tableClient.QueryAsync<SharedAnalysisEntity>(filter: $"RowKey eq '{id}'"))
+                await foreach (var e in _storage.SharedAnalysesTable.QueryAsync<SharedAnalysisEntity>(filter: $"RowKey eq '{id}'"))
                 {
                     entity = e;
                     break;
@@ -473,7 +480,7 @@ public class SharingFunctions
         }
 
         // Clean up old table entries
-        await foreach (var entity in _tableClient.QueryAsync<SharedAnalysisEntity>())
+        await foreach (var entity in _storage.SharedAnalysesTable.QueryAsync<SharedAnalysisEntity>())
         {
             var ownerId = entity.UserId;
             
@@ -494,7 +501,7 @@ public class SharingFunctions
                 _logger.LogInformation("Deleting table entry {Id} for user {UserId} with tier {Tier} (cutoff: {CutoffDate})", 
                     entity.RowKey, ownerId, userTier, cutoffDateTime);
 
-                await _tableClient.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
+                await _storage.SharedAnalysesTable.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
                 deletedTableCount++;
             }
             else
@@ -533,10 +540,12 @@ public class SharingFunctions
 
         try
         {
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
             var savedAnalyses = new List<SharedAnalysisEntity>();
 
             // Query table storage for all analyses owned by this user
-            await foreach (var entity in _tableClient.QueryAsync<SharedAnalysisEntity>(
+            await foreach (var entity in _storage.SharedAnalysesTable.QueryAsync<SharedAnalysisEntity>(
                 filter: $"PartitionKey eq '{user.UserId}'"))
             {
                 savedAnalyses.Add(entity);
@@ -602,8 +611,10 @@ public class SharingFunctions
 
         try
         {
+            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
             // First, check if the analysis exists and belongs to the user
-            var existingEntity = await _tableClient.GetEntityIfExistsAsync<SharedAnalysisEntity>(user.UserId, id);
+            var existingEntity = await _storage.SharedAnalysesTable.GetEntityIfExistsAsync<SharedAnalysisEntity>(user.UserId, id);
             
             if (!existingEntity.HasValue)
             {
@@ -613,7 +624,7 @@ public class SharingFunctions
             }
 
             // Delete from table storage
-            await _tableClient.DeleteEntityAsync(user.UserId, id);
+            await _storage.SharedAnalysesTable.DeleteEntityAsync(user.UserId, id);
 
             // Delete from blob storage
             var blobClient = containerClient.GetBlobClient($"{id}.json");

--- a/feedbackfunctions/Utils/ReportGenerator.cs
+++ b/feedbackfunctions/Utils/ReportGenerator.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SharedDump.AI;
@@ -23,8 +22,7 @@ public class ReportGenerator
     private readonly IRedditService _redditService;
     private readonly IGitHubService _githubService;
     private readonly IFeedbackAnalyzerService _analyzerService;
-    private readonly BlobContainerClient _containerClient;
-    private readonly BlobContainerClient _summaryContainerClient;
+    private readonly IReportStorageService _reportStorage;
     private readonly IReportCacheService? _cacheService;
     private readonly IConfiguration _configuration;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -34,7 +32,7 @@ public class ReportGenerator
         IRedditService redditService,
         IGitHubService githubService,
         IFeedbackAnalyzerService analyzerService,
-        BlobServiceClient blobServiceClient,
+        IReportStorageService reportStorage,
         IConfiguration configuration,
         IReportCacheService? cacheService = null)
     {
@@ -42,15 +40,9 @@ public class ReportGenerator
         _redditService = redditService;
         _githubService = githubService;
         _analyzerService = analyzerService;
+        _reportStorage = reportStorage;
         _configuration = configuration;
         _cacheService = cacheService;
-        
-        // Initialize both blob container clients
-        _containerClient = blobServiceClient.GetBlobContainerClient("reports");
-        _containerClient.CreateIfNotExists();
-        
-        _summaryContainerClient = blobServiceClient.GetBlobContainerClient("reports-summary");
-        _summaryContainerClient.CreateIfNotExists();
     }
 
     /// <summary>
@@ -412,11 +404,12 @@ Keep each section very brief and focused. Total analysis should be no more than 
     public async Task<string> StoreReportAsync(ReportModel report)
     {
         _logger.LogInformation("Storing report {ReportId} to blob storage", report.Id);
+        await _reportStorage.EnsureInitializedAsync();
 
         try
         {
             var blobName = $"{report.Id}.json";
-            var blobClient = _containerClient.GetBlobClient(blobName);
+            var blobClient = _reportStorage.ReportsContainer.GetBlobClient(blobName);
             
             var reportJson = JsonSerializer.Serialize(report);
             await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(reportJson));
@@ -447,11 +440,12 @@ Keep each section very brief and focused. Total analysis should be no more than 
     public async Task<string> StoreSummaryReportAsync(ReportModel report)
     {
         _logger.LogInformation("Storing summary report {ReportId} to blob storage", report.Id);
+        await _reportStorage.EnsureInitializedAsync();
 
         try
         {
             var blobName = $"{report.Id}-summary.json";
-            var blobClient = _summaryContainerClient.GetBlobClient(blobName);
+            var blobClient = _reportStorage.ReportsSummaryContainer.GetBlobClient(blobName);
             
             var reportJson = JsonSerializer.Serialize(report);
             await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(reportJson));
@@ -475,6 +469,8 @@ Keep each section very brief and focused. Total analysis should be no more than 
     /// <returns>The most recent summary report if found within 24 hours, otherwise null</returns>
     public async Task<ReportModel?> GetRecentSummaryReportAsync(string source, string subSource)
     {
+        await _reportStorage.EnsureInitializedAsync();
+
         try
         {
             _logger.LogDebug("Checking for recent summary reports with source '{Source}' and subsource '{SubSource}'", source, subSource);
@@ -482,13 +478,13 @@ Keep each section very brief and focused. Total analysis should be no more than 
             var cutoff = DateTimeOffset.UtcNow.AddHours(-24);
             var recentReport = (ReportModel?)null;
             
-            await foreach (var blob in _summaryContainerClient.GetBlobsAsync())
+            await foreach (var blob in _reportStorage.ReportsSummaryContainer.GetBlobsAsync())
             {
                 if (blob.Properties.LastModified >= cutoff)
                 {
                     try
                     {
-                        var blobClient = _summaryContainerClient.GetBlobClient(blob.Name);
+                        var blobClient = _reportStorage.ReportsSummaryContainer.GetBlobClient(blob.Name);
                         var content = await blobClient.DownloadContentAsync();
                         var report = JsonSerializer.Deserialize<ReportModel>(content.Value.Content, _jsonOptions);
                         


### PR DESCRIPTION
This is the first implementation slice in the perf roadmap. The goal is to remove avoidable Azure Functions cold-start and per-constructor storage work before moving on to the higher-volume query and cache improvements in the next phases.

This change centralizes storage client creation in DI, adds a memoized deferred initializer for the shared storage scopes, and introduces a shared report-storage abstraction so report-related functions and services stop rebuilding Blob/Table clients or doing `CreateIfNotExists` work in constructors. It also rewires the remaining hot paths that were still constructing storage clients directly (`UserAccountService`, `ApiKeyService`, `AuthUserTableService`, `AdminReportConfigService`, `DigestEmailProcessorFunction`, `AuthUserManagement`, `SharingFunctions`, and the report function set) onto the shared layer.

A couple of non-obvious points worth reviewing:

- Initialization is now **deferred first use** rather than forced during host startup, which keeps startup work off the cold path while still preserving table/container creation behavior.
- I used a typed shared storage holder (`FeedbackStorageClients`) rather than keyed DI registrations for individual clients, which kept the refactor smaller and constructor injection simpler across Functions classes.
- This PR is intentionally foundation-only; it does **not** tackle the later request/query optimizations planned for #227 and #228.

It also adds focused tests around `TableInitializationService` so the one-time memoized initialization behavior stays protected as the later perf phases build on top of this.