### PR TITLE
Avoid full report cache warmup for targeted reads

### DIFF
--- a/feedbackfunctions/Reports/ReportFunctions.cs
+++ b/feedbackfunctions/Reports/ReportFunctions.cs
@@ -217,33 +217,37 @@ public class ReportingFunctions
                 return emptyResponse;
             }
 
-            // Get all reports from cache
-            var allReports = await _cacheService.GetReportsAsync();
-            var cacheReadElapsedMs = stopwatch.ElapsedMilliseconds;
-            var matchingReports = new List<object>();
-
-            foreach (var report in allReports)
-            {
-                // Check if this report matches any of the user's requests
-                var matchesRequest = userReportRequests.Any(userReq =>
-                    userReq.Type == report.Source &&
-                    ((userReq.Type == "reddit" && userReq.Subreddit == report.SubSource) ||
-                     (userReq.Type == "github" && $"{userReq.Owner}/{userReq.Repo}" == report.SubSource)));
-
-                if (matchesRequest)
+            var allReports = new List<ReportModel>();
+            foreach (var userRequest in userReportRequests
+                .Select(request => new
                 {
-                    matchingReports.Add(new
-                    {
-                        id = report.Id,
-                        source = report.Source,
-                        subSource = report.SubSource,
-                        generatedAt = report.GeneratedAt,
-                        threadCount = report.ThreadCount,
-                        commentCount = report.CommentCount,
-                        cutoffDate = report.CutoffDate
-                    });
-                }
+                    Source = request.Type,
+                    SubSource = request.Type == "reddit"
+                        ? request.Subreddit
+                        : $"{request.Owner}/{request.Repo}"
+                })
+                .Where(request => !string.IsNullOrWhiteSpace(request.Source) && !string.IsNullOrWhiteSpace(request.SubSource))
+                .Distinct())
+            {
+                var reportsForRequest = await _cacheService.GetReportsAsync(userRequest.Source, userRequest.SubSource);
+                allReports.AddRange(reportsForRequest);
             }
+
+            var cacheReadElapsedMs = stopwatch.ElapsedMilliseconds;
+            var matchingReports = allReports
+                .DistinctBy(report => report.Id)
+                .Select(report => new
+                {
+                    id = report.Id,
+                    source = report.Source,
+                    subSource = report.SubSource,
+                    generatedAt = report.GeneratedAt,
+                    threadCount = report.ThreadCount,
+                    commentCount = report.CommentCount,
+                    cutoffDate = report.CutoffDate
+                })
+                .Cast<object>()
+                .ToList();
 
             // Sort by generation date (newest first)
             matchingReports = matchingReports

--- a/feedbackfunctions/Services/Reports/ReportCacheService.cs
+++ b/feedbackfunctions/Services/Reports/ReportCacheService.cs
@@ -19,6 +19,7 @@ public class ReportCacheService : IReportCacheService
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
     
     private DateTime _lastRefresh = DateTime.MinValue;
+    private bool _isFullCacheHydrated;
     private static readonly TimeSpan CacheExpiry = TimeSpan.FromHours(24);
 
     /// <summary>
@@ -36,7 +37,6 @@ public class ReportCacheService : IReportCacheService
     public async Task<ReportModel?> GetReportAsync(string reportId)
     {
         var stopwatch = Stopwatch.StartNew();
-        await EnsureCacheIsValidAsync();
 
         if (_cache.TryGetValue(reportId, out var cachedReport))
         {
@@ -92,8 +92,22 @@ public class ReportCacheService : IReportCacheService
     /// <inheritdoc />
     public async Task<List<ReportModel>> GetReportsAsync(string? sourceFilter = null, string? subsourceFilter = null)
     {
-        await EnsureCacheIsValidAsync();
+        if (string.IsNullOrEmpty(sourceFilter) && string.IsNullOrEmpty(subsourceFilter))
+        {
+            await EnsureFullCacheIsValidAsync();
+            return FilterCachedReports(sourceFilter, subsourceFilter);
+        }
 
+        if (_isFullCacheHydrated && !IsCacheExpired())
+        {
+            return FilterCachedReports(sourceFilter, subsourceFilter);
+        }
+
+        return await LoadFilteredReportsAsync(sourceFilter, subsourceFilter);
+    }
+
+    private List<ReportModel> FilterCachedReports(string? sourceFilter, string? subsourceFilter)
+    {
         var reports = _cache.Values
             .Select(cr => cr.Report)
             .Where(report => 
@@ -110,6 +124,62 @@ public class ReportCacheService : IReportCacheService
             reports.Count, sourceFilter ?? "any", subsourceFilter ?? "any");
 
         return reports;
+    }
+
+    private async Task<List<ReportModel>> LoadFilteredReportsAsync(string? sourceFilter, string? subsourceFilter)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var matchedReports = new Dictionary<string, ReportModel>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var cachedReport in FilterCachedReports(sourceFilter, subsourceFilter))
+        {
+            matchedReports[cachedReport.Id.ToString()] = cachedReport;
+        }
+
+        await foreach (var blob in _containerClient.GetBlobsAsync())
+        {
+            try
+            {
+                var blobClient = _containerClient.GetBlobClient(blob.Name);
+                var content = await blobClient.DownloadContentAsync();
+                var report = JsonSerializer.Deserialize<ReportModel>(content.Value.Content, _jsonOptions);
+
+                if (report == null)
+                {
+                    continue;
+                }
+
+                var matchesSource = string.IsNullOrEmpty(sourceFilter) ||
+                    string.Equals(report.Source, sourceFilter, StringComparison.OrdinalIgnoreCase);
+                var matchesSubsource = string.IsNullOrEmpty(subsourceFilter) ||
+                    string.Equals(report.SubSource, subsourceFilter, StringComparison.OrdinalIgnoreCase);
+
+                if (!matchesSource || !matchesSubsource)
+                {
+                    continue;
+                }
+
+                _cache.AddOrUpdate(
+                    report.Id.ToString(),
+                    new CachedReport(report, DateTime.UtcNow),
+                    (_, _) => new CachedReport(report, DateTime.UtcNow));
+                matchedReports[report.Id.ToString()] = report;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load filtered report from blob {BlobName}", blob.Name);
+            }
+        }
+
+        _lastRefresh = DateTime.UtcNow;
+        _logger.LogInformation(
+            "ReportCache.LoadFilteredReportsAsync loaded {Count} filtered reports in {ElapsedMs}ms for source={Source} subsource={Subsource}",
+            matchedReports.Count,
+            stopwatch.ElapsedMilliseconds,
+            sourceFilter ?? "any",
+            subsourceFilter ?? "any");
+
+        return matchedReports.Values.ToList();
     }
 
     /// <inheritdoc />
@@ -143,6 +213,7 @@ public class ReportCacheService : IReportCacheService
     {
         _cache.Clear();
         _lastRefresh = DateTime.MinValue;
+        _isFullCacheHydrated = false;
         _logger.LogInformation("Cleared all cached reports");
         await Task.CompletedTask;
     }
@@ -187,6 +258,7 @@ public class ReportCacheService : IReportCacheService
             }
 
             _lastRefresh = DateTime.UtcNow;
+            _isFullCacheHydrated = true;
             _logger.LogInformation(
                 "Cache refresh completed. Loaded {Count} reports in {ElapsedMs}ms",
                 loadedCount,
@@ -201,12 +273,10 @@ public class ReportCacheService : IReportCacheService
     /// <summary>
     /// Ensures the cache is valid and refreshes if needed
     /// </summary>
-    private async Task EnsureCacheIsValidAsync()
+    private async Task EnsureFullCacheIsValidAsync()
     {
         var stopwatch = Stopwatch.StartNew();
-        // Only refresh if cache is completely empty and has never been refreshed
-        // This prevents automatic refresh during testing
-        if (_cache.IsEmpty && _lastRefresh == DateTime.MinValue)
+        if (!_isFullCacheHydrated && _cache.IsEmpty)
         {
             try
             {
@@ -220,9 +290,8 @@ public class ReportCacheService : IReportCacheService
                 _logger.LogWarning(ex, "Failed to refresh cache automatically, continuing with empty cache");
             }
         }
-        else if (_lastRefresh != DateTime.MinValue && DateTime.UtcNow - _lastRefresh > CacheExpiry)
+        else if (_isFullCacheHydrated && IsCacheExpired())
         {
-            // Only refresh if cache was previously loaded and has expired
             try
             {
                 await RefreshCacheAsync();
@@ -242,6 +311,9 @@ public class ReportCacheService : IReportCacheService
                 stopwatch.ElapsedMilliseconds);
         }
     }
+
+    private bool IsCacheExpired() =>
+        _lastRefresh != DateTime.MinValue && DateTime.UtcNow - _lastRefresh > CacheExpiry;
 
     /// <summary>
     /// Represents a cached report with timestamp


### PR DESCRIPTION
This is a focused slice of the report-cache work for #227. The main problem here is that several request paths only need a narrow subset of reports, but the cache service was hydrating the entire report cache on first use and GetUserReports was then scanning all cached reports in memory.

This change keeps the broad RefreshCacheAsync behavior for explicit/full-cache scenarios, but changes targeted reads to avoid that cold-start warmup. GetReportAsync now falls back directly to the requested blob without forcing a full cache refresh, filtered GetReportsAsync calls perform a targeted blob scan and cache only the matches they need, and GetUserReports now queries by each requested source/subsource instead of loading every report and filtering afterward.

A couple of things worth reviewing:

- This PR is intentionally scoped to the targeted read path. It does not try to solve the remaining eports-summary/listing follow-up or introduce a metadata index yet.
- Full-cache hydration is still available through the existing full read/refresh path; the change is that narrow reads no longer pay that global warmup cost.
- I preserved the existing in-memory cache semantics for explicitly cached reports, so callers that set reports in-process still get them back without an unexpected reload.

This gives us a smaller, safer perf improvement now while keeping the next #227 follow-up available for the broader summary/listing optimization.