### PR TITLE
Use point reads for exact-key table lookups

### DIFF
--- a/feedbackfunctions/Account/AuthUserManagement.cs
+++ b/feedbackfunctions/Account/AuthUserManagement.cs
@@ -463,17 +463,10 @@ public class AuthUserManagement : IDisposable
                     
                     try
                     {
-                        // Query for the corresponding global request
-                        var globalQuery = globalTableClient.QueryAsync<ReportRequestModel>(
-                            filter: $"PartitionKey eq '{globalPartitionKey}' and RowKey eq '{globalRequestId}'",
-                            maxPerPage: 1);
-
-                        ReportRequestModel? globalRequest = null;
-                        await foreach (var entity in globalQuery)
-                        {
-                            globalRequest = entity;
-                            break;
-                        }
+                        var globalRequestResponse = await globalTableClient.GetEntityIfExistsAsync<ReportRequestModel>(
+                            globalPartitionKey,
+                            globalRequestId);
+                        var globalRequest = globalRequestResponse.HasValue ? globalRequestResponse.Value : null;
 
                         if (globalRequest != null)
                         {

--- a/feedbackfunctions/Reports/ReportRequestFunctions.cs
+++ b/feedbackfunctions/Reports/ReportRequestFunctions.cs
@@ -282,16 +282,10 @@ public class ReportRequestFunctions
             try
             {
                 // Check if this user already has this request
-                var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
-                    filter: $"PartitionKey eq '{request.PartitionKey}' and RowKey eq '{request.RowKey}'",
-                    maxPerPage: 1);
-
-                UserReportRequestModel? existingEntity = null;
-                await foreach (var entity in existingEntities)
-                {
-                    existingEntity = entity;
-                    break;
-                }
+                var existingEntityResponse = await _userRequestsTableClient.GetEntityIfExistsAsync<UserReportRequestModel>(
+                    request.PartitionKey,
+                    request.RowKey);
+                var existingEntity = existingEntityResponse.HasValue ? existingEntityResponse.Value : null;
                 
                 if (existingEntity != null)
                 {
@@ -322,16 +316,10 @@ public class ReportRequestFunctions
                 globalRequest.RowKey = globalRequestId;
 
                 // Check if global request exists and increment subscriber count
-                var globalExistingEntities = _tableClient.QueryAsync<ReportRequestModel>(
-                    filter: $"PartitionKey eq '{globalRequest.PartitionKey}' and RowKey eq '{globalRequest.RowKey}'",
-                    maxPerPage: 1);
-
-                ReportRequestModel? globalExistingEntity = null;
-                await foreach (var entity in globalExistingEntities)
-                {
-                    globalExistingEntity = entity;
-                    break;
-                }
+                var globalExistingEntityResponse = await _tableClient.GetEntityIfExistsAsync<ReportRequestModel>(
+                    globalRequest.PartitionKey,
+                    globalRequest.RowKey);
+                var globalExistingEntity = globalExistingEntityResponse.HasValue ? globalExistingEntityResponse.Value : null;
                 
                 if (globalExistingEntity != null)
                 {
@@ -432,16 +420,10 @@ public class ReportRequestFunctions
             try
             {
                 // Check if user request exists
-                var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
-                    filter: $"PartitionKey eq '{partitionKey}' and RowKey eq '{rowKey}'",
-                    maxPerPage: 1);
-
-                UserReportRequestModel? existingEntity = null;
-                await foreach (var entity in existingEntities)
-                {
-                    existingEntity = entity;
-                    break;
-                }
+                var existingEntityResponse = await _userRequestsTableClient.GetEntityIfExistsAsync<UserReportRequestModel>(
+                    partitionKey,
+                    rowKey);
+                var existingEntity = existingEntityResponse.HasValue ? existingEntityResponse.Value : null;
                 
                 if (existingEntity == null)
                 {
@@ -465,16 +447,10 @@ public class ReportRequestFunctions
                 var globalRequestId = GenerateRequestId(globalRequest);
                 var globalPartitionKey = globalRequest.Type.ToLowerInvariant();
 
-                var globalExistingEntities = _tableClient.QueryAsync<ReportRequestModel>(
-                    filter: $"PartitionKey eq '{globalPartitionKey}' and RowKey eq '{globalRequestId}'",
-                    maxPerPage: 1);
-
-                ReportRequestModel? globalExistingEntity = null;
-                await foreach (var entity in globalExistingEntities)
-                {
-                    globalExistingEntity = entity;
-                    break;
-                }
+                var globalExistingEntityResponse = await _tableClient.GetEntityIfExistsAsync<ReportRequestModel>(
+                    globalPartitionKey,
+                    globalRequestId);
+                var globalExistingEntity = globalExistingEntityResponse.HasValue ? globalExistingEntityResponse.Value : null;
                 
                 if (globalExistingEntity != null)
                 {
@@ -561,16 +537,10 @@ public class ReportRequestFunctions
             var rowKey = id;
 
             // Check if user request exists
-            var existingEntities = _userRequestsTableClient.QueryAsync<UserReportRequestModel>(
-                filter: $"PartitionKey eq '{partitionKey}' and RowKey eq '{rowKey}'",
-                maxPerPage: 1);
-
-            UserReportRequestModel? existingEntity = null;
-            await foreach (var entity in existingEntities)
-            {
-                existingEntity = entity;
-                break;
-            }
+            var existingEntityResponse = await _userRequestsTableClient.GetEntityIfExistsAsync<UserReportRequestModel>(
+                partitionKey,
+                rowKey);
+            var existingEntity = existingEntityResponse.HasValue ? existingEntityResponse.Value : null;
             
             if (existingEntity == null)
             {

--- a/feedbackfunctions/Utils/ApiKeyValidationHelper.cs
+++ b/feedbackfunctions/Utils/ApiKeyValidationHelper.cs
@@ -69,16 +69,15 @@ public static class ApiKeyValidationHelper
     {
         try
         {
-            var isValid = await apiKeyService.ValidateApiKeyAsync(apiKey);
-            if (!isValid)
+            var apiKeyRecord = await apiKeyService.GetApiKeyByKeyAsync(apiKey);
+            if (apiKeyRecord == null || !apiKeyRecord.IsEnabled)
             {
                 var errorResponse = req.CreateResponse(HttpStatusCode.Unauthorized);
                 await errorResponse.WriteStringAsync("Invalid or disabled API key. Contact admin to enable your API key.");
                 return (false, errorResponse, null);
             }
 
-            // Get user ID for usage tracking
-            var userId = await apiKeyService.GetUserIdByApiKeyAsync(apiKey);
+            var userId = apiKeyRecord.UserId;
             if (string.IsNullOrEmpty(userId))
             {
                 logger.LogError("Could not find user ID for valid API key");


### PR DESCRIPTION
This is the first low-risk slice of the #228 table/query work. Several request paths already knew the exact PartitionKey and RowKey they needed, but were still doing table queries and then enumerating the first result.

This change replaces those exact-key query scans with point reads in the report-request and account-cleanup paths, and it also removes one duplicate API key load during request validation by reusing the already-fetched API key record instead of validating and then looking it up again.

A couple of things worth reviewing:

- The scope is intentionally narrow: this PR targets exact-key reads only and does not yet tackle the broader report-listing or digest batching follow-up from #228.
- Behavior is unchanged; the paths still return the same not-found/conflict responses, they just reach those outcomes with direct entity reads instead of query enumeration.
- The API key validation helper now treats the fetched key entity as the source of truth for both enabled-state validation and user-ID resolution, which removes redundant table work on successful API requests.

This keeps the change reviewable while moving the highest-confidence #228 wins forward first.