### PR TITLE
[feedbackfunctions] Phase 1 X/Twitter API call optimizations

### DIFF
--- a/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
+++ b/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
@@ -1,0 +1,122 @@
+using FeedbackFunctions.Services.Twitter;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SharedDump.Models.TwitterFeedback;
+using System.Threading;
+
+namespace FeedbackFlow.Tests;
+
+[TestClass]
+public class TwitterThreadCacheServiceTests
+{
+    private ILogger<TwitterThreadCacheService> _logger = null!;
+    private IConfiguration _configuration = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _logger = Substitute.For<ILogger<TwitterThreadCacheService>>();
+        _configuration = Substitute.For<IConfiguration>();
+        _configuration["Twitter:ThreadCacheTTL"].Returns("00:05:00");
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_RepeatedKey_ReturnsCacheHitWithoutRefetch()
+    {
+        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var fetchCount = 0;
+        var response = CreateResponse("123");
+
+        var first = await service.GetThreadAsync(
+            "123",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(response);
+            });
+
+        var second = await service.GetThreadAsync(
+            "123",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("123"));
+            });
+
+        Assert.IsFalse(first.CacheHit);
+        Assert.IsTrue(second.CacheHit);
+        Assert.AreEqual(1, fetchCount);
+        Assert.IsNotNull(second.Response);
+        Assert.AreEqual("123", second.Response.Items[0].Id);
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_ForceRefresh_BypassesCache()
+    {
+        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var fetchCount = 0;
+
+        await service.GetThreadAsync(
+            "123",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("123"));
+            });
+
+        var refreshed = await service.GetThreadAsync(
+            "123",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("123"));
+            },
+            forceRefresh: true);
+
+        Assert.IsFalse(refreshed.CacheHit);
+        Assert.AreEqual(2, fetchCount);
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_ConcurrentCalls_SingleFlightsFetch()
+    {
+        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var fetchCount = 0;
+
+        async Task<TwitterFeedbackResponse?> FetchAsync()
+        {
+            Interlocked.Increment(ref fetchCount);
+            await Task.Delay(150);
+            return CreateResponse("999");
+        }
+
+        var firstTask = service.GetThreadAsync("999", FetchAsync);
+        var secondTask = service.GetThreadAsync("999", FetchAsync);
+
+        await Task.WhenAll(firstTask, secondTask);
+
+        Assert.AreEqual(1, fetchCount);
+        Assert.IsFalse(firstTask.Result.CacheHit);
+        Assert.IsTrue(secondTask.Result.CacheHit);
+    }
+
+    private static TwitterFeedbackResponse CreateResponse(string id) =>
+        new()
+        {
+            Items =
+            [
+                new TwitterFeedbackItem
+                {
+                    Id = id,
+                    Author = "tester",
+                    AuthorName = "Tester",
+                    AuthorUsername = "tester",
+                    Content = "hello",
+                    TimestampUtc = DateTime.UtcNow,
+                    Replies = []
+                }
+            ],
+            ProcessedTweetCount = 1
+        };
+}

--- a/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
+++ b/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
@@ -97,8 +97,10 @@ public class TwitterThreadCacheServiceTests
         await Task.WhenAll(firstTask, secondTask);
 
         Assert.AreEqual(1, fetchCount);
-        Assert.IsFalse(firstTask.Result.CacheHit);
-        Assert.IsTrue(secondTask.Result.CacheHit);
+        var cacheHitCount = new[] { firstTask.Result, secondTask.Result }.Count(result => result.CacheHit);
+        var cacheMissCount = new[] { firstTask.Result, secondTask.Result }.Count(result => !result.CacheHit);
+        Assert.AreEqual(1, cacheHitCount);
+        Assert.AreEqual(1, cacheMissCount);
     }
 
     private static TwitterFeedbackResponse CreateResponse(string id) =>

--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -24,6 +24,7 @@ using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
 using FeedbackFunctions.Services.Account;
+using FeedbackFunctions.Services.Twitter;
 using FeedbackFunctions.Utils;
 using SharedDump.Models.Account;
 
@@ -49,6 +50,7 @@ public class FeedbackFunctions
     private readonly IBlueSkyService _blueSkyService;
     private readonly AuthenticationMiddleware _authMiddleware;
     private readonly IUserAccountService _userAccountService;
+    private readonly ITwitterThreadCacheService _twitterThreadCacheService;
 
     /// <summary>
     /// Initializes a new instance of the FeedbackFunctions class
@@ -73,7 +75,8 @@ public class FeedbackFunctions
         ITwitterService twitterService,
         IBlueSkyService blueSkyService,
         AuthenticationMiddleware authMiddleware,
-        IUserAccountService userAccountService)
+        IUserAccountService userAccountService,
+        ITwitterThreadCacheService twitterThreadCacheService)
     {
         _logger = logger;
         _githubService = githubService;
@@ -86,6 +89,7 @@ public class FeedbackFunctions
         _blueSkyService = blueSkyService;
         _authMiddleware = authMiddleware;
         _userAccountService = userAccountService;
+        _twitterThreadCacheService = twitterThreadCacheService;
     }
 
     /// <summary>
@@ -632,6 +636,7 @@ public class FeedbackFunctions
     public async Task<HttpResponseData> GetTwitterFeedback(
         [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
     {
+        var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Processing Twitter/X feedback request");
         
         // Authenticate the request
@@ -662,6 +667,7 @@ public class FeedbackFunctions
             
         var queryParams = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
         var tweetUrlOrId = queryParams["tweet"];
+        var forceRefresh = bool.TryParse(queryParams["forceRefresh"], out var parsedForceRefresh) && parsedForceRefresh;
         if (string.IsNullOrWhiteSpace(tweetUrlOrId))
         {
             var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
@@ -670,7 +676,11 @@ public class FeedbackFunctions
         }
         try
         {
-            var result = await _twitterService.GetTwitterThreadAsync(tweetUrlOrId);
+            var cachedResult = await _twitterThreadCacheService.GetThreadAsync(
+                tweetUrlOrId,
+                () => _twitterService.GetTwitterThreadAsync(tweetUrlOrId),
+                forceRefresh);
+            var result = cachedResult.Response;
             if (result == null)
             {
                 var notFound = req.CreateResponse(HttpStatusCode.NotFound);
@@ -683,12 +693,21 @@ public class FeedbackFunctions
             
             // Track usage on successful completion
             await user!.TrackUsageAsync(UsageType.FeedQuery, _userAccountService, _logger, tweetUrlOrId);
+
+            _logger.LogInformation(
+                "GetTwitterFeedback performance: totalMs={TotalMs}, cacheHit={CacheHit}, forceRefresh={ForceRefresh}, cacheKey={CacheKey}, mayBeIncomplete={MayBeIncomplete}, itemCount={ItemCount}",
+                stopwatch.ElapsedMilliseconds,
+                cachedResult.CacheHit,
+                forceRefresh,
+                cachedResult.CacheKey,
+                result.MayBeIncomplete,
+                result.Items?.Count ?? 0);
             
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing Twitter feedback request");
+            _logger.LogError(ex, "Error processing Twitter feedback request after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
             var response = req.CreateResponse(HttpStatusCode.InternalServerError);
             await response.WriteStringAsync("An error occurred processing the request");
             return response;
@@ -1013,9 +1032,18 @@ public class FeedbackFunctions
 
     private async Task<object> GetTwitterDataForAnalysis(string url)
     {
-        var result = await _twitterService.GetTwitterThreadAsync(url);
+        var cachedResult = await _twitterThreadCacheService.GetThreadAsync(
+            url,
+            () => _twitterService.GetTwitterThreadAsync(url));
+        var result = cachedResult.Response;
         if (result == null)
             throw new InvalidOperationException("Could not fetch Twitter/X feedback");
+
+        _logger.LogInformation(
+            "AutoAnalyze Twitter cache usage: cacheHit={CacheHit}, cacheKey={CacheKey}, itemCount={ItemCount}",
+            cachedResult.CacheHit,
+            cachedResult.CacheKey,
+            result.Items?.Count ?? 0);
 
         return result;
     }

--- a/feedbackfunctions/OmniSearch/OmniSearchService.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchService.cs
@@ -168,6 +168,7 @@ public class OmniSearchService
         finally
         {
             cacheLock.Release();
+            _cacheLocks.TryRemove(cacheKey, out _);
         }
     }
 

--- a/feedbackfunctions/OmniSearch/OmniSearchService.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchService.cs
@@ -29,6 +29,7 @@ public class OmniSearchService
     
     // In-memory cache for search results
     private static readonly ConcurrentDictionary<string, (OmniSearchResponse Response, DateTimeOffset CachedAt)> _cache = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _cacheLocks = new();
     private readonly TimeSpan _cacheTTL;
     private readonly int _maxConcurrency;
 
@@ -63,6 +64,7 @@ public class OmniSearchService
         FeedbackFunctions.Services.Account.IUserAccountService userAccountService,
         CancellationToken cancellationToken = default)
     {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         // Check cache first
         var cacheKey = GenerateCacheKey(request);
         if (_cache.TryGetValue(cacheKey, out var cached))
@@ -72,6 +74,12 @@ public class OmniSearchService
                 _logger.LogInformation("Cache hit for omni-search query: {Query}", request.Query);
                 // Still track usage even on cache hit - user is consuming the resource
                 await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+                _logger.LogInformation(
+                    "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
+                    stopwatch.ElapsedMilliseconds,
+                    true,
+                    request.Platforms.Count,
+                    cached.Response.TotalCount);
                 return cached.Response;
             }
             else
@@ -81,57 +89,86 @@ public class OmniSearchService
             }
         }
 
-        _logger.LogInformation("Executing omni-search for query: {Query} across platforms: {Platforms}", 
-            request.Query, string.Join(", ", request.Platforms));
-
-        var results = new List<OmniSearchResult>();
-        var searchTasks = new List<Task<List<OmniSearchResult>>>();
-
-        // Launch platform searches in parallel
-        foreach (var platform in request.Platforms)
+        var cacheLock = _cacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+        await cacheLock.WaitAsync(cancellationToken);
+        try
         {
-            searchTasks.Add(SearchPlatformAsync(platform.ToLowerInvariant(), request, cancellationToken));
-        }
+            if (_cache.TryGetValue(cacheKey, out cached) &&
+                DateTimeOffset.UtcNow - cached.CachedAt < _cacheTTL)
+            {
+                await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+                _logger.LogInformation(
+                    "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
+                    stopwatch.ElapsedMilliseconds,
+                    true,
+                    request.Platforms.Count,
+                    cached.Response.TotalCount);
+                return cached.Response;
+            }
 
-        // Wait for all platforms to complete
-        var platformResults = await Task.WhenAll(searchTasks);
+            _logger.LogInformation("Executing omni-search for query: {Query} across platforms: {Platforms}", 
+                request.Query, string.Join(", ", request.Platforms));
+
+            var results = new List<OmniSearchResult>();
+            var searchTasks = new List<Task<List<OmniSearchResult>>>();
+
+            // Launch platform searches in parallel
+            foreach (var platform in request.Platforms)
+            {
+                searchTasks.Add(SearchPlatformAsync(platform.ToLowerInvariant(), request, cancellationToken));
+            }
+
+            // Wait for all platforms to complete
+            var platformResults = await Task.WhenAll(searchTasks);
         
-        // Merge results
-        foreach (var platformResult in platformResults)
-        {
-            results.AddRange(platformResult);
-        }
+            // Merge results
+            foreach (var platformResult in platformResults)
+            {
+                results.AddRange(platformResult);
+            }
 
-        // Sort results (filtering for zero comments is handled on client side)
-        results = request.SortMode.ToLowerInvariant() == "ranked"
-            ? RankResults(results)
-            : results.OrderByDescending(r => r.CommentCount).ThenByDescending(r => r.PublishedAt).ToList();
+            // Sort results (filtering for zero comments is handled on client side)
+            results = request.SortMode.ToLowerInvariant() == "ranked"
+                ? RankResults(results)
+                : results.OrderByDescending(r => r.CommentCount).ThenByDescending(r => r.PublishedAt).ToList();
 
-        // Don't apply pagination - return all results from all platforms
-        // If user selects 2 platforms, they get 200 results (100 per platform)
-        var totalCount = results.Count;
+            // Don't apply pagination - return all results from all platforms
+            // If user selects 2 platforms, they get 200 results (100 per platform)
+            var totalCount = results.Count;
 
-        var response = new OmniSearchResponse
-        {
-            Results = results, // Return all results, no pagination
-            TotalCount = totalCount,
-            Page = 1,
-            PageSize = totalCount, // PageSize equals total count
-            CachedAt = DateTimeOffset.UtcNow,
-            Query = request.Query,
-            PlatformsSearched = request.Platforms
-        };
+            var response = new OmniSearchResponse
+            {
+                Results = results, // Return all results, no pagination
+                TotalCount = totalCount,
+                Page = 1,
+                PageSize = totalCount, // PageSize equals total count
+                CachedAt = DateTimeOffset.UtcNow,
+                Query = request.Query,
+                PlatformsSearched = request.Platforms
+            };
 
-        // Cache the response
-        _cache[cacheKey] = (response, DateTimeOffset.UtcNow);
+            // Cache the response
+            _cache[cacheKey] = (response, DateTimeOffset.UtcNow);
         
-        _logger.LogInformation("Omni-search completed. Found {Count} total results across {PlatformCount} platforms", 
-            totalCount, request.Platforms.Count);
+            _logger.LogInformation("Omni-search completed. Found {Count} total results across {PlatformCount} platforms", 
+                totalCount, request.Platforms.Count);
 
-        // Track usage - one credit per platform searched
-        await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+            // Track usage - one credit per platform searched
+            await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
 
-        return response;
+            _logger.LogInformation(
+                "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
+                stopwatch.ElapsedMilliseconds,
+                false,
+                request.Platforms.Count,
+                totalCount);
+
+            return response;
+        }
+        finally
+        {
+            cacheLock.Release();
+        }
     }
 
     /// <summary>

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -21,6 +21,7 @@ using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Email;
 using FeedbackFunctions.Services.Storage;
+using FeedbackFunctions.Services.Twitter;
 using System.Configuration;
 using FeedbackFunctions.Services.Reports;
 using FeedbackFunctions.Utils;
@@ -73,6 +74,7 @@ builder.Services.AddSingleton<IAdminReportConfigService, AdminReportConfigServic
 
 // Register OmniSearch service
 builder.Services.AddScoped<OmniSearchService>();
+builder.Services.AddSingleton<ITwitterThreadCacheService, TwitterThreadCacheService>();
 
 // Register services based on UseMocks setting
 if (useMocks)

--- a/feedbackfunctions/Services/Twitter/ITwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/ITwitterThreadCacheService.cs
@@ -1,0 +1,17 @@
+using SharedDump.Models.TwitterFeedback;
+
+namespace FeedbackFunctions.Services.Twitter;
+
+public interface ITwitterThreadCacheService
+{
+    Task<TwitterThreadCacheResult> GetThreadAsync(
+        string tweetUrlOrId,
+        Func<Task<TwitterFeedbackResponse?>> fetchThreadAsync,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default);
+}
+
+public readonly record struct TwitterThreadCacheResult(
+    TwitterFeedbackResponse? Response,
+    bool CacheHit,
+    string CacheKey);

--- a/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
@@ -18,7 +18,15 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
         IConfiguration configuration)
     {
         _logger = logger;
-        _cacheTtl = TimeSpan.Parse(configuration["Twitter:ThreadCacheTTL"] ?? "00:05:00");
+        var cacheTtlConfig = configuration["Twitter:ThreadCacheTTL"];
+        if (!TimeSpan.TryParse(cacheTtlConfig, out _cacheTtl))
+        {
+            _cacheTtl = TimeSpan.FromMinutes(5);
+            _logger.LogWarning(
+                "Invalid Twitter:ThreadCacheTTL value '{ConfiguredValue}'. Using default {DefaultTtl}.",
+                cacheTtlConfig,
+                _cacheTtl);
+        }
     }
 
     public async Task<TwitterThreadCacheResult> GetThreadAsync(
@@ -49,7 +57,7 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
             }
 
             _logger.LogInformation(
-                "TwitterThreadCache fetched upstream result for key {CacheKey}. forceRefresh={ForceRefresh}, cached={Cached}, ttlSeconds={TtlSeconds}",
+                "TwitterThreadCache fetched upstream result for key {CacheKey}. forceRefresh={ForceRefresh}, storedInCache={StoredInCache}, ttlSeconds={TtlSeconds}",
                 cacheKey,
                 forceRefresh,
                 response is not null,
@@ -60,6 +68,7 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
         finally
         {
             cacheLock.Release();
+            _cacheLocks.TryRemove(cacheKey, out _);
         }
     }
 

--- a/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
@@ -1,0 +1,92 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using SharedDump.Models.TwitterFeedback;
+using SharedDump.Utils;
+
+namespace FeedbackFunctions.Services.Twitter;
+
+public class TwitterThreadCacheService : ITwitterThreadCacheService
+{
+    private readonly ILogger<TwitterThreadCacheService> _logger;
+    private readonly TimeSpan _cacheTtl;
+    private readonly ConcurrentDictionary<string, CachedThread> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _cacheLocks = new(StringComparer.OrdinalIgnoreCase);
+
+    public TwitterThreadCacheService(
+        ILogger<TwitterThreadCacheService> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _cacheTtl = TimeSpan.Parse(configuration["Twitter:ThreadCacheTTL"] ?? "00:05:00");
+    }
+
+    public async Task<TwitterThreadCacheResult> GetThreadAsync(
+        string tweetUrlOrId,
+        Func<Task<TwitterFeedbackResponse?>> fetchThreadAsync,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        var cacheKey = BuildCacheKey(tweetUrlOrId);
+        if (!forceRefresh && TryGetValidEntry(cacheKey, out var cachedResponse))
+        {
+            return new TwitterThreadCacheResult(cachedResponse, true, cacheKey);
+        }
+
+        var cacheLock = _cacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+        await cacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!forceRefresh && TryGetValidEntry(cacheKey, out cachedResponse))
+            {
+                return new TwitterThreadCacheResult(cachedResponse, true, cacheKey);
+            }
+
+            var response = await fetchThreadAsync();
+            if (response is not null)
+            {
+                _cache[cacheKey] = new CachedThread(response, DateTimeOffset.UtcNow);
+            }
+
+            _logger.LogInformation(
+                "TwitterThreadCache fetched upstream result for key {CacheKey}. forceRefresh={ForceRefresh}, cached={Cached}, ttlSeconds={TtlSeconds}",
+                cacheKey,
+                forceRefresh,
+                response is not null,
+                _cacheTtl.TotalSeconds);
+
+            return new TwitterThreadCacheResult(response, false, cacheKey);
+        }
+        finally
+        {
+            cacheLock.Release();
+        }
+    }
+
+    private bool TryGetValidEntry(string cacheKey, out TwitterFeedbackResponse? response)
+    {
+        if (_cache.TryGetValue(cacheKey, out var cached) &&
+            DateTimeOffset.UtcNow - cached.CachedAt < _cacheTtl)
+        {
+            response = cached.Response;
+            return true;
+        }
+
+        _cache.TryRemove(cacheKey, out _);
+        response = null;
+        return false;
+    }
+
+    private static string BuildCacheKey(string tweetUrlOrId)
+    {
+        var tweetId = TwitterUrlParser.ExtractTweetId(tweetUrlOrId);
+        if (!string.IsNullOrWhiteSpace(tweetId))
+        {
+            return $"tweet:{tweetId.Trim().ToLowerInvariant()}";
+        }
+
+        return $"raw:{tweetUrlOrId.Trim().ToLowerInvariant()}";
+    }
+
+    private readonly record struct CachedThread(TwitterFeedbackResponse Response, DateTimeOffset CachedAt);
+}

--- a/feedbackwebapp/Components/Pages/Home.razor
+++ b/feedbackwebapp/Components/Pages/Home.razor
@@ -443,10 +443,24 @@
     // URL normalization and comparison helpers for reanalyze feature
     private string[] NormalizeUrls(IEnumerable<string> urls) => urls
         .Where(u => !string.IsNullOrWhiteSpace(u))
-        .Select(u => u.Trim().ToLowerInvariant()) // Normalize casing  
+        .Select(u => NormalizeUrlForComparison(u.Trim()))
         .Distinct()
         .OrderBy(u => u)
         .ToArray();
+
+    private static string NormalizeUrlForComparison(string url)
+    {
+        if (UrlParsing.IsTwitterUrl(url))
+        {
+            var tweetId = TwitterUrlParser.ExtractTweetId(url);
+            if (!string.IsNullOrWhiteSpace(tweetId))
+            {
+                return $"twitter:{tweetId.Trim().ToLowerInvariant()}";
+            }
+        }
+
+        return url.ToLowerInvariant();
+    }
 
     private bool UrlsUnchanged()
     {
@@ -669,6 +683,14 @@
 
         try
         {
+            var urls = autoDataSourceForm?.GetUrls() ?? new List<string>();
+            if (hasComments && UrlsUnchanged())
+            {
+                currentStatus = FeedbackProcessStatus.Completed;
+                currentStatusMessage = "Using existing fetched comments for unchanged URLs.";
+                return;
+            }
+
             // Reset previous data but preserve any existing analysis for re-fetch scenario
             error = "";
             markdownResult = "";
@@ -682,8 +704,6 @@
             currentStatusMessage = "Fetching comments...";
             showSurveyLink = false;
             StateHasChanged();
-
-            var urls = autoDataSourceForm?.GetUrls() ?? new List<string>();
             
             // Check Twitter access before fetching
             var (hasAccess, accessError) = await TwitterAccessService.CheckTwitterAccessAsync(urls);

--- a/feedbackwebapp/Services/Feedback/AutoDataSourceFeedbackService.cs
+++ b/feedbackwebapp/Services/Feedback/AutoDataSourceFeedbackService.cs
@@ -25,9 +25,9 @@ public class AutoDataSourceFeedbackService: FeedbackService, IAutoDataSourceFeed
         FeedbackStatusUpdate? onStatusUpdate = null)
         : base(http, configuration, userSettings, authenticationHeaderService, onStatusUpdate)
     {
-        _urls = urls;
+        _urls = NormalizeInputUrls(urls);
         _serviceProvider = serviceProvider;
-    }    
+    }
     
     private string GetServiceType(string url)
     {
@@ -77,18 +77,14 @@ public class AutoDataSourceFeedbackService: FeedbackService, IAutoDataSourceFeed
             try
             {
                 var serviceType = GetServiceType(url);
-                var service = ResolveFeedbackService(url);
-                if (service != null)
+                var (comments, commentCount, additionalData) = await GetCommentsFromUrl(url);
+                if (!string.IsNullOrWhiteSpace(comments))
                 {
-                    var (comments, commentCount, additionalData) = await GetCommentsFromUrl(url);
-                    if (!string.IsNullOrWhiteSpace(comments))
-                    {
-                        sourceData.Add(new FeedbackSourceData(serviceType, $"URL: {url}\n{comments}", commentCount, additionalData));
-                        totalCommentCount += commentCount;
-                        
-                        UpdateStatus(FeedbackProcessStatus.GatheringComments, 
-                            $"Collected {commentCount} comments from URL {processedCount}...");
-                    }
+                    sourceData.Add(new FeedbackSourceData(serviceType, $"URL: {url}\n{comments}", commentCount, additionalData));
+                    totalCommentCount += commentCount;
+                    
+                    UpdateStatus(FeedbackProcessStatus.GatheringComments, 
+                        $"Collected {commentCount} comments from URL {processedCount}...");
                 }
             }
             catch (Exception ex)
@@ -223,6 +219,27 @@ public class AutoDataSourceFeedbackService: FeedbackService, IAutoDataSourceFeed
     }
 
     private IFeedbackService? ResolveFeedbackService(string url) => _serviceProvider.GetService(url);
+
+    private static string[] NormalizeInputUrls(IEnumerable<string> urls) => urls
+        .Where(url => !string.IsNullOrWhiteSpace(url))
+        .Select(url => url.Trim())
+        .GroupBy(GetCanonicalUrlKey, StringComparer.OrdinalIgnoreCase)
+        .Select(group => group.First())
+        .ToArray();
+
+    private static string GetCanonicalUrlKey(string url)
+    {
+        if (UrlParsing.IsTwitterUrl(url))
+        {
+            var tweetId = TwitterUrlParser.ExtractTweetId(url);
+            if (!string.IsNullOrWhiteSpace(tweetId))
+            {
+                return $"twitter:{tweetId.Trim().ToLowerInvariant()}";
+            }
+        }
+
+        return url.Trim().ToLowerInvariant();
+    }
 }
 
 

--- a/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
+++ b/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using SharedDump.Json;
@@ -16,12 +17,15 @@ public class TwitterFeedbackFetcher
     private int _maxReplySearches = 60; // Limit per 15 minutes
     private int _currentReplySearches = 0;
     private HashSet<string> _processedTweetIds = new();
+    private const int MaxRetryAttempts = 3;
 
     public TwitterFeedbackFetcher(HttpClient httpClient, ILogger<TwitterFeedbackFetcher> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }    private async Task<List<TwitterFeedbackItem>> FetchRepliesRecursivelyAsync(string conversationId, string parentTweetId, string authorId, CancellationToken cancellationToken)
+    }
+
+    private async Task<List<TwitterFeedbackItem>> FetchRepliesRecursivelyAsync(string conversationId, string parentTweetId, string authorId, CancellationToken cancellationToken)
     {
         // Check if we hit rate limits
         if (_hitRateLimit || _currentReplySearches >= _maxReplySearches)
@@ -47,7 +51,7 @@ public class TwitterFeedbackFetcher
         
         // Modified query to get all replies in the conversation
         // Instead of excluding the author, we get all tweets in the conversation
-        var baseUrl = $"https://api.twitter.com/2/tweets/search/recent?query=conversation_id:{conversationId}&tweet.fields=author_id,created_at,conversation_id,in_reply_to_user_id,referenced_tweets&expansions=author_id,referenced_tweets.id&user.fields=name,username&max_results=100";
+        var baseUrl = $"https://api.twitter.com/2/tweets/search/recent?query=conversation_id:{conversationId}&tweet.fields=author_id,created_at,referenced_tweets&expansions=author_id&user.fields=name,username&max_results=100";
 
         do
         {
@@ -60,7 +64,11 @@ public class TwitterFeedbackFetcher
                 repliesUrl += $"&next_token={nextToken}";
             }
 
-            var repliesResp = await _httpClient.GetAsync(repliesUrl, cancellationToken);
+            var repliesResp = await GetWithRetryAsync(repliesUrl, $"conversation replies for {parentTweetId}", cancellationToken);
+            if (repliesResp is null)
+            {
+                break;
+            }
 
             if (!repliesResp.IsSuccessStatusCode)
             {
@@ -197,9 +205,14 @@ public class TwitterFeedbackFetcher
             }
 
             // Fetch the main tweet with more comprehensive information
-            var tweetResp = await _httpClient.GetAsync(
-                $"https://api.twitter.com/2/tweets/{tweetId}?tweet.fields=author_id,created_at,conversation_id,referenced_tweets&expansions=author_id,referenced_tweets.id&user.fields=name,username", 
+            var tweetResp = await GetWithRetryAsync(
+                $"https://api.twitter.com/2/tweets/{tweetId}?tweet.fields=author_id,created_at,conversation_id,referenced_tweets&expansions=author_id&user.fields=name,username",
+                $"main tweet {tweetId}",
                 cancellationToken);
+            if (tweetResp is null)
+            {
+                return null;
+            }
                 
             if (!tweetResp.IsSuccessStatusCode)
             {
@@ -290,6 +303,11 @@ public class TwitterFeedbackFetcher
                 response.RateLimitInfo = $"Some replies may be missing due to Twitter API rate limits (60 reply searches per 15 minutes). Processed {_processedTweetIds.Count} unique tweets.";
             }
 
+            _logger.LogInformation(
+                "Twitter thread fetch performance: processedTweetCount={ProcessedTweetCount}, replySearches={ReplySearches}, mayBeIncomplete={MayBeIncomplete}",
+                response.ProcessedTweetCount,
+                _currentReplySearches,
+                response.MayBeIncomplete);
             return response;
         }
         catch (Exception ex)
@@ -297,7 +315,9 @@ public class TwitterFeedbackFetcher
             _logger.LogError(ex, "Failed to fetch Twitter feedback for {TweetUrlOrId}", tweetUrlOrId);
             return null;
         }
-    }/// <summary>
+    }
+
+    /// <summary>
     /// Organizes a flat list of replies into a proper tree structure based on ParentId
     /// </summary>
     private void OrganizeRepliesIntoTree(TwitterFeedbackItem rootTweet, List<TwitterFeedbackItem> allReplies)
@@ -402,7 +422,7 @@ public class TwitterFeedbackFetcher
             var escapedQuery = Uri.EscapeDataString(enhancedQuery);
             
             var searchUrl = $"https://api.twitter.com/2/tweets/search/recent?query={escapedQuery}" +
-                           $"&tweet.fields=author_id,created_at,public_metrics" +
+                           $"&tweet.fields=author_id,created_at" +
                            $"&expansions=author_id" +
                            $"&user.fields=name,username" +
                            $"&max_results={Math.Min(maxResults, 100)}";
@@ -420,7 +440,11 @@ public class TwitterFeedbackFetcher
 
             _logger.LogInformation("Twitter search URL: {Url}", searchUrl.Replace(_httpClient.DefaultRequestHeaders.Authorization?.ToString() ?? "", "[AUTH]"));
 
-            var response = await _httpClient.GetAsync(searchUrl, cancellationToken);
+            var response = await GetWithRetryAsync(searchUrl, $"search for query '{query}'", cancellationToken);
+            if (response is null)
+            {
+                return results;
+            }
 
             if (!response.IsSuccessStatusCode)
             {
@@ -472,6 +496,64 @@ public class TwitterFeedbackFetcher
             _logger.LogError(ex, "Error searching Twitter");
             return results;
         }
+    }
+
+    private async Task<HttpResponseMessage?> GetWithRetryAsync(string requestUrl, string operation, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= MaxRetryAttempts; attempt++)
+        {
+            var response = await _httpClient.GetAsync(requestUrl, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return response;
+            }
+
+            if (!ShouldRetry(response.StatusCode) || attempt == MaxRetryAttempts)
+            {
+                return response;
+            }
+
+            var delay = GetRetryDelay(response, attempt);
+            _logger.LogWarning(
+                "Retrying Twitter API request for {Operation}. status={StatusCode}, attempt={Attempt}, delayMs={DelayMs}",
+                operation,
+                (int)response.StatusCode,
+                attempt,
+                delay.TotalMilliseconds);
+
+            response.Dispose();
+            await Task.Delay(delay, cancellationToken);
+        }
+
+        return null;
+    }
+
+    private static bool ShouldRetry(HttpStatusCode statusCode) =>
+        statusCode == HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
+    {
+        if (response.Headers.RetryAfter?.Delta is { } retryAfterDelta && retryAfterDelta > TimeSpan.Zero)
+        {
+            return retryAfterDelta;
+        }
+
+        if (response.Headers.TryGetValues("x-rate-limit-reset", out var resetValues))
+        {
+            var resetValue = resetValues.FirstOrDefault();
+            if (long.TryParse(resetValue, out var unixReset))
+            {
+                var resetAt = DateTimeOffset.FromUnixTimeSeconds(unixReset);
+                var untilReset = resetAt - DateTimeOffset.UtcNow;
+                if (untilReset > TimeSpan.Zero)
+                {
+                    return untilReset;
+                }
+            }
+        }
+
+        var seconds = Math.Min((int)Math.Pow(2, attempt), 30);
+        return TimeSpan.FromSeconds(seconds);
     }
 
 }

--- a/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
+++ b/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
@@ -18,6 +18,7 @@ public class TwitterFeedbackFetcher
     private int _currentReplySearches = 0;
     private HashSet<string> _processedTweetIds = new();
     private const int MaxRetryAttempts = 3;
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
 
     public TwitterFeedbackFetcher(HttpClient httpClient, ILogger<TwitterFeedbackFetcher> logger)
     {
@@ -64,7 +65,7 @@ public class TwitterFeedbackFetcher
                 repliesUrl += $"&next_token={nextToken}";
             }
 
-            var repliesResp = await GetWithRetryAsync(repliesUrl, $"conversation replies for {parentTweetId}", cancellationToken);
+            using var repliesResp = await GetWithRetryAsync(repliesUrl, $"conversation replies for {parentTweetId}", cancellationToken);
             if (repliesResp is null)
             {
                 break;
@@ -188,7 +189,9 @@ public class TwitterFeedbackFetcher
         } while (!string.IsNullOrEmpty(nextToken) && !cancellationToken.IsCancellationRequested && !_hitRateLimit && _currentReplySearches < _maxReplySearches);
 
         return replies;
-    }    public async Task<TwitterFeedbackResponse?> FetchFeedbackAsync(string tweetUrlOrId, CancellationToken cancellationToken = default)
+    }
+
+    public async Task<TwitterFeedbackResponse?> FetchFeedbackAsync(string tweetUrlOrId, CancellationToken cancellationToken = default)
     {
         // Reset tracking variables
         _hitRateLimit = false;
@@ -205,7 +208,7 @@ public class TwitterFeedbackFetcher
             }
 
             // Fetch the main tweet with more comprehensive information
-            var tweetResp = await GetWithRetryAsync(
+            using var tweetResp = await GetWithRetryAsync(
                 $"https://api.twitter.com/2/tweets/{tweetId}?tweet.fields=author_id,created_at,conversation_id,referenced_tweets&expansions=author_id&user.fields=name,username",
                 $"main tweet {tweetId}",
                 cancellationToken);
@@ -440,7 +443,7 @@ public class TwitterFeedbackFetcher
 
             _logger.LogInformation("Twitter search URL: {Url}", searchUrl.Replace(_httpClient.DefaultRequestHeaders.Authorization?.ToString() ?? "", "[AUTH]"));
 
-            var response = await GetWithRetryAsync(searchUrl, $"search for query '{query}'", cancellationToken);
+            using var response = await GetWithRetryAsync(searchUrl, $"search for query '{query}'", cancellationToken);
             if (response is null)
             {
                 return results;
@@ -531,14 +534,14 @@ public class TwitterFeedbackFetcher
     private static bool ShouldRetry(HttpStatusCode statusCode) =>
         statusCode == HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
 
-    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
+    private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
     {
+        var delay = TimeSpan.Zero;
         if (response.Headers.RetryAfter?.Delta is { } retryAfterDelta && retryAfterDelta > TimeSpan.Zero)
         {
-            return retryAfterDelta;
+            delay = retryAfterDelta;
         }
-
-        if (response.Headers.TryGetValues("x-rate-limit-reset", out var resetValues))
+        else if (response.Headers.TryGetValues("x-rate-limit-reset", out var resetValues))
         {
             var resetValue = resetValues.FirstOrDefault();
             if (long.TryParse(resetValue, out var unixReset))
@@ -547,13 +550,27 @@ public class TwitterFeedbackFetcher
                 var untilReset = resetAt - DateTimeOffset.UtcNow;
                 if (untilReset > TimeSpan.Zero)
                 {
-                    return untilReset;
+                    delay = untilReset;
                 }
             }
         }
 
-        var seconds = Math.Min((int)Math.Pow(2, attempt), 30);
-        return TimeSpan.FromSeconds(seconds);
+        if (delay <= TimeSpan.Zero)
+        {
+            var seconds = Math.Min((int)Math.Pow(2, attempt), (int)MaxRetryDelay.TotalSeconds);
+            delay = TimeSpan.FromSeconds(seconds);
+        }
+
+        if (delay > MaxRetryDelay)
+        {
+            _logger.LogWarning(
+                "Capping Twitter retry delay from {OriginalDelayMs}ms to {CappedDelayMs}ms to avoid long-running function waits.",
+                delay.TotalMilliseconds,
+                MaxRetryDelay.TotalMilliseconds);
+            return MaxRetryDelay;
+        }
+
+        return delay;
     }
 
 }


### PR DESCRIPTION
## Summary
- add function-level Twitter thread cache with per-key single-flight coalescing
- integrate cache-first Twitter retrieval into GetTwitterFeedback and AutoAnalyze Twitter path
- harden OmniSearch cache misses with in-flight single-flight protection and performance metrics
- reduce Twitter API payload defaults and add retry/backoff handling for 429/5xx with rate-limit reset support
- dedupe/canonicalize Auto URL inputs (including Twitter ID canonicalization) and short-circuit unchanged refresh fetches
- add targeted tests for Twitter thread cache behavior

## Validation
- dotnet build FeedbackFlow.slnx --configuration Release
- dotnet test FeedbackFlow.slnx --configuration Release

## Tracking
- Phase 1 issue: #243
- Phase 2 roadmap: #244
- Phase 3 roadmap: #245