### PR TITLE
[feedbackfunctions] Phase 2 optional L2 Twitter cache

### DIFF
--- a/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
+++ b/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
@@ -1,7 +1,9 @@
 using FeedbackFunctions.Services.Twitter;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using SharedDump.Json;
 using SharedDump.Models.TwitterFeedback;
 using System.Threading;
 
@@ -12,19 +14,22 @@ public class TwitterThreadCacheServiceTests
 {
     private ILogger<TwitterThreadCacheService> _logger = null!;
     private IConfiguration _configuration = null!;
+    private IDistributedCache _distributedCache = null!;
 
     [TestInitialize]
     public void Setup()
     {
         _logger = Substitute.For<ILogger<TwitterThreadCacheService>>();
         _configuration = Substitute.For<IConfiguration>();
+        _distributedCache = Substitute.For<IDistributedCache>();
         _configuration["Twitter:ThreadCacheTTL"].Returns("00:05:00");
+        _configuration["Twitter:UseL2Cache"].Returns("false");
     }
 
     [TestMethod]
     public async Task GetThreadAsync_RepeatedKey_ReturnsCacheHitWithoutRefetch()
     {
-        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
         var fetchCount = 0;
         var response = CreateResponse("123");
 
@@ -54,7 +59,7 @@ public class TwitterThreadCacheServiceTests
     [TestMethod]
     public async Task GetThreadAsync_ForceRefresh_BypassesCache()
     {
-        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
         var fetchCount = 0;
 
         await service.GetThreadAsync(
@@ -81,7 +86,7 @@ public class TwitterThreadCacheServiceTests
     [TestMethod]
     public async Task GetThreadAsync_ConcurrentCalls_SingleFlightsFetch()
     {
-        var service = new TwitterThreadCacheService(_logger, _configuration);
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
         var fetchCount = 0;
 
         async Task<TwitterFeedbackResponse?> FetchAsync()
@@ -101,6 +106,38 @@ public class TwitterThreadCacheServiceTests
         var cacheMissCount = new[] { firstTask.Result, secondTask.Result }.Count(result => !result.CacheHit);
         Assert.AreEqual(1, cacheHitCount);
         Assert.AreEqual(1, cacheMissCount);
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_L2CacheHit_ReturnsWithoutRefetch()
+    {
+        // Arrange
+        _configuration["Twitter:UseL2Cache"].Returns("true");
+        _configuration["Twitter:ThreadL2CacheTTL"].Returns("00:30:00");
+        var l2Response = CreateResponse("42");
+        var l2Payload = System.Text.Json.JsonSerializer.Serialize(
+            l2Response,
+            TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+        _distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(System.Text.Encoding.UTF8.GetBytes(l2Payload));
+
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
+        var fetchCount = 0;
+
+        // Act
+        var result = await service.GetThreadAsync(
+            "https://x.com/user/status/42",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("42"));
+            });
+
+        // Assert
+        Assert.IsTrue(result.CacheHit);
+        Assert.AreEqual(0, fetchCount);
+        Assert.IsNotNull(result.Response);
+        Assert.AreEqual("42", result.Response.Items[0].Id);
     }
 
     private static TwitterFeedbackResponse CreateResponse(string id) =>

--- a/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
+++ b/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
@@ -140,6 +140,49 @@ public class TwitterThreadCacheServiceTests
         Assert.AreEqual("42", result.Response.Items[0].Id);
     }
 
+    [TestMethod]
+    public async Task GetThreadAsync_InvalidL2Payload_FallsBackToFetch()
+    {
+        _configuration["Twitter:UseL2Cache"].Returns("true");
+        _distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(System.Text.Encoding.UTF8.GetBytes("{invalid-json"));
+
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
+        var fetchCount = 0;
+
+        var result = await service.GetThreadAsync(
+            "https://x.com/user/status/55",
+            () =>
+            {
+                Interlocked.Increment(ref fetchCount);
+                return Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("55"));
+            });
+
+        Assert.AreEqual(1, fetchCount);
+        Assert.IsFalse(result.CacheHit);
+        Assert.IsNotNull(result.Response);
+        await _distributedCache.Received(2).RemoveAsync("raw:https://x.com/user/status/55", Arg.Any<CancellationToken>());
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_L2WriteFailure_DoesNotFailRequest()
+    {
+        _configuration["Twitter:UseL2Cache"].Returns("true");
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("cache unavailable")));
+
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
+
+        var result = await service.GetThreadAsync(
+            "https://x.com/user/status/77",
+            () => Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("77")));
+
+        Assert.IsNotNull(result.Response);
+        Assert.AreEqual("77", result.Response.Items[0].Id);
+        Assert.IsFalse(result.CacheHit);
+    }
+
     private static TwitterFeedbackResponse CreateResponse(string id) =>
         new()
         {

--- a/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
+++ b/feedbackflow.tests/TwitterThreadCacheServiceTests.cs
@@ -183,6 +183,46 @@ public class TwitterThreadCacheServiceTests
         Assert.IsFalse(result.CacheHit);
     }
 
+    [TestMethod]
+    public async Task GetThreadAsync_L2ReadCancellation_PropagatesCancellation()
+    {
+        _configuration["Twitter:UseL2Cache"].Returns("true");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromCanceled<byte[]?>(cts.Token));
+
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => service.GetThreadAsync(
+            "https://x.com/user/status/88",
+            () => Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("88")),
+            cancellationToken: cts.Token));
+    }
+
+    [TestMethod]
+    public async Task GetThreadAsync_L2WriteCancellation_PropagatesCancellation()
+    {
+        _configuration["Twitter:UseL2Cache"].Returns("true");
+        using var cts = new CancellationTokenSource();
+        _distributedCache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<byte[]?>(null));
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cts.Cancel();
+                return Task.FromCanceled(cts.Token);
+            });
+
+        var service = new TwitterThreadCacheService(_logger, _configuration, _distributedCache);
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => service.GetThreadAsync(
+            "https://x.com/user/status/99",
+            () => Task.FromResult<TwitterFeedbackResponse?>(CreateResponse("99")),
+            cancellationToken: cts.Token));
+    }
+
     private static TwitterFeedbackResponse CreateResponse(string id) =>
         new()
         {

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -48,6 +48,7 @@ throwIfNullOrEmpty = true;
 
 // Register HTTP client factory
 builder.Services.AddHttpClient();
+builder.Services.AddDistributedMemoryCache();
 
 // Configure default timeout for all HttpClients to 3 minutes
 builder.Services.ConfigureHttpClientDefaults(http =>

--- a/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
@@ -137,13 +137,34 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
             return null;
         }
 
-        var cachedPayload = await _distributedCache.GetStringAsync(cacheKey, cancellationToken);
-        if (string.IsNullOrWhiteSpace(cachedPayload))
+        try
         {
+            var cachedPayload = await _distributedCache.GetStringAsync(cacheKey, cancellationToken);
+            if (string.IsNullOrWhiteSpace(cachedPayload))
+            {
+                return null;
+            }
+
+            return JsonSerializer.Deserialize(cachedPayload, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize L2 Twitter cache payload for key {CacheKey}. Falling back to upstream fetch.", cacheKey);
+            try
+            {
+                await _distributedCache.RemoveAsync(cacheKey, cancellationToken);
+            }
+            catch (Exception removeEx)
+            {
+                _logger.LogWarning(removeEx, "Failed to evict malformed L2 Twitter cache key {CacheKey}.", cacheKey);
+            }
             return null;
         }
-
-        return JsonSerializer.Deserialize(cachedPayload, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read L2 Twitter cache for key {CacheKey}. Falling back to upstream fetch.", cacheKey);
+            return null;
+        }
     }
 
     private async Task SetL2EntryAsync(string cacheKey, TwitterFeedbackResponse response, CancellationToken cancellationToken)
@@ -158,7 +179,14 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
         {
             AbsoluteExpirationRelativeToNow = _l2CacheTtl
         };
-        await _distributedCache.SetStringAsync(cacheKey, payload, options, cancellationToken);
+        try
+        {
+            await _distributedCache.SetStringAsync(cacheKey, payload, options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write L2 Twitter cache for key {CacheKey}. Continuing without L2 cache update.", cacheKey);
+        }
     }
 
     private static string BuildCacheKey(string tweetUrlOrId)

--- a/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
@@ -154,11 +154,19 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
             {
                 await _distributedCache.RemoveAsync(cacheKey, cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception removeEx)
             {
                 _logger.LogWarning(removeEx, "Failed to evict malformed L2 Twitter cache key {CacheKey}.", cacheKey);
             }
             return null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -174,14 +182,18 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
             return;
         }
 
-        var payload = JsonSerializer.Serialize(response, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
-        var options = new DistributedCacheEntryOptions
-        {
-            AbsoluteExpirationRelativeToNow = _l2CacheTtl
-        };
         try
         {
+            var payload = JsonSerializer.Serialize(response, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = _l2CacheTtl
+            };
             await _distributedCache.SetStringAsync(cacheKey, payload, options, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
+++ b/feedbackfunctions/Services/Twitter/TwitterThreadCacheService.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using SharedDump.Json;
 using SharedDump.Models.TwitterFeedback;
 using SharedDump.Utils;
 
@@ -10,14 +13,19 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
 {
     private readonly ILogger<TwitterThreadCacheService> _logger;
     private readonly TimeSpan _cacheTtl;
+    private readonly TimeSpan _l2CacheTtl;
+    private readonly bool _useL2Cache;
+    private readonly IDistributedCache? _distributedCache;
     private readonly ConcurrentDictionary<string, CachedThread> _cache = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _cacheLocks = new(StringComparer.OrdinalIgnoreCase);
 
     public TwitterThreadCacheService(
         ILogger<TwitterThreadCacheService> logger,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IDistributedCache? distributedCache = null)
     {
         _logger = logger;
+        _distributedCache = distributedCache;
         var cacheTtlConfig = configuration["Twitter:ThreadCacheTTL"];
         if (!TimeSpan.TryParse(cacheTtlConfig, out _cacheTtl))
         {
@@ -26,6 +34,20 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
                 "Invalid Twitter:ThreadCacheTTL value '{ConfiguredValue}'. Using default {DefaultTtl}.",
                 cacheTtlConfig,
                 _cacheTtl);
+        }
+
+        _useL2Cache = bool.TryParse(configuration["Twitter:UseL2Cache"], out var useL2Cache) && useL2Cache;
+
+        var l2CacheTtlConfig = configuration["Twitter:ThreadL2CacheTTL"];
+        if (!TimeSpan.TryParse(l2CacheTtlConfig, out _l2CacheTtl))
+        {
+            _l2CacheTtl = TimeSpan.FromMinutes(30);
+        }
+
+        if (_useL2Cache && _distributedCache is null)
+        {
+            _logger.LogWarning(
+                "Twitter:UseL2Cache is enabled but no IDistributedCache is registered. Running with L1 cache only.");
         }
     }
 
@@ -41,6 +63,16 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
             return new TwitterThreadCacheResult(cachedResponse, true, cacheKey);
         }
 
+        if (!forceRefresh)
+        {
+            var l2CachedResponse = await TryGetL2EntryAsync(cacheKey, cancellationToken);
+            if (l2CachedResponse is not null)
+            {
+                _cache[cacheKey] = new CachedThread(l2CachedResponse, DateTimeOffset.UtcNow);
+                return new TwitterThreadCacheResult(l2CachedResponse, true, cacheKey);
+            }
+        }
+
         var cacheLock = _cacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
         await cacheLock.WaitAsync(cancellationToken);
         try
@@ -50,18 +82,30 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
                 return new TwitterThreadCacheResult(cachedResponse, true, cacheKey);
             }
 
+            if (!forceRefresh)
+            {
+                var l2CachedResponse = await TryGetL2EntryAsync(cacheKey, cancellationToken);
+                if (l2CachedResponse is not null)
+                {
+                    _cache[cacheKey] = new CachedThread(l2CachedResponse, DateTimeOffset.UtcNow);
+                    return new TwitterThreadCacheResult(l2CachedResponse, true, cacheKey);
+                }
+            }
+
             var response = await fetchThreadAsync();
             if (response is not null)
             {
                 _cache[cacheKey] = new CachedThread(response, DateTimeOffset.UtcNow);
+                await SetL2EntryAsync(cacheKey, response, cancellationToken);
             }
 
             _logger.LogInformation(
-                "TwitterThreadCache fetched upstream result for key {CacheKey}. forceRefresh={ForceRefresh}, storedInCache={StoredInCache}, ttlSeconds={TtlSeconds}",
+                "TwitterThreadCache fetched upstream result for key {CacheKey}. forceRefresh={ForceRefresh}, storedInCache={StoredInCache}, l1TtlSeconds={L1TtlSeconds}, l2Enabled={L2Enabled}",
                 cacheKey,
                 forceRefresh,
                 response is not null,
-                _cacheTtl.TotalSeconds);
+                _cacheTtl.TotalSeconds,
+                _useL2Cache);
 
             return new TwitterThreadCacheResult(response, false, cacheKey);
         }
@@ -84,6 +128,37 @@ public class TwitterThreadCacheService : ITwitterThreadCacheService
         _cache.TryRemove(cacheKey, out _);
         response = null;
         return false;
+    }
+
+    private async Task<TwitterFeedbackResponse?> TryGetL2EntryAsync(string cacheKey, CancellationToken cancellationToken)
+    {
+        if (!_useL2Cache || _distributedCache is null)
+        {
+            return null;
+        }
+
+        var cachedPayload = await _distributedCache.GetStringAsync(cacheKey, cancellationToken);
+        if (string.IsNullOrWhiteSpace(cachedPayload))
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize(cachedPayload, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+    }
+
+    private async Task SetL2EntryAsync(string cacheKey, TwitterFeedbackResponse response, CancellationToken cancellationToken)
+    {
+        if (!_useL2Cache || _distributedCache is null)
+        {
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(response, TwitterFeedbackJsonContext.Default.TwitterFeedbackResponse);
+        var options = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = _l2CacheTtl
+        };
+        await _distributedCache.SetStringAsync(cacheKey, payload, options, cancellationToken);
     }
 
     private static string BuildCacheKey(string tweetUrlOrId)

--- a/feedbackfunctions/local.settings.json
+++ b/feedbackfunctions/local.settings.json
@@ -16,7 +16,10 @@
       "AccessToken": ""
     },
     "Twitter": {
-      "BearerToken": ""
+      "BearerToken": "",
+      "UseL2Cache": false,
+      "ThreadCacheTTL": "00:05:00",
+      "ThreadL2CacheTTL": "00:30:00"
     },
     "BlueSky": {
       "Username": "",


### PR DESCRIPTION
## Summary
- add optional IDistributedCache-backed L2 path to TwitterThreadCacheService
- gate L2 with Twitter:UseL2Cache and configure dedicated Twitter:ThreadL2CacheTTL
- keep existing L1 in-memory cache and single-flight behavior intact
- harden L2 reliability: malformed payload fallback, bad-key eviction, and best-effort read/write failures
- add tests covering L2 cache hit, malformed L2 payload fallback, and L2 write failure tolerance

## Validation
- dotnet build FeedbackFlow.slnx --configuration Release
- dotnet test FeedbackFlow.slnx --configuration Release

## Context
- Follows Phase 1 merged PR and advances Phase 2 cache architecture work.