### PR TITLE
[feedbackfunctions] Phase 3 usage guardrails and rollout hardening

### DIFF
--- a/feedbackfunctions/Extensions/UsageValidationExtensions.cs
+++ b/feedbackfunctions/Extensions/UsageValidationExtensions.cs
@@ -53,6 +53,18 @@ public static class UsageValidationExtensions
                 
                 return errorResponse;
             }
+
+            if (result.IsNearLimit)
+            {
+                logger?.LogWarning(
+                    "Usage near limit for user {UserId}: type={UsageType}, usage={CurrentUsage}/{Limit} ({UsagePercentage}%), remaining={RemainingUsage}",
+                    user.UserId,
+                    usageType,
+                    result.CurrentUsage,
+                    result.Limit,
+                    result.UsagePercentage,
+                    result.RemainingUsage);
+            }
             
             return null; // Validation passed
         }

--- a/feedbackfunctions/Services/Account/UserAccountService.cs
+++ b/feedbackfunctions/Services/Account/UserAccountService.cs
@@ -342,11 +342,20 @@ public class UserAccountService : IUserAccountService
         var currentUsage = GetCurrentUsage(user, usageType);
         var usageLimit = GetLimitForUsageType(limits, usageType);
         var remainingUsage = Math.Max(usageLimit - currentUsage, 0);
-        var usagePercentage = usageLimit > 0
-            ? (int)Math.Round((double)currentUsage / usageLimit * 100, MidpointRounding.AwayFromZero)
-            : 0;
+        var usagePercentage = 0;
+        if (usageLimit > 0)
+        {
+            usagePercentage = (int)Math.Floor((double)currentUsage / usageLimit * 100);
+            usagePercentage = Math.Min(usagePercentage, 100);
+            if (withinLimit && usagePercentage >= 100)
+            {
+                usagePercentage = 99;
+            }
+        }
+
         var warningThresholdPercentage = GetConfigValue("Usage:WarningThresholdPercent", 80);
         var isNearLimit = withinLimit && usageLimit > 0 && usagePercentage >= warningThresholdPercentage;
+        var usageDisplayLabel = GetUsageDisplayLabel(usageType, remainingUsage);
 
         return new UsageValidationResult 
         { 
@@ -358,7 +367,7 @@ public class UserAccountService : IUserAccountService
             UsagePercentage = usagePercentage,
             IsNearLimit = isNearLimit,
             WarningMessage = isNearLimit
-                ? $"You have {remainingUsage} {usageType} usage remaining this period."
+                ? $"You have {remainingUsage} {usageDisplayLabel} remaining this period."
                 : null,
             CurrentTier = user.Tier,
             ResetDate = usageType == UsageType.ReportCreated ? null : user.LastResetDate.AddDays(30),
@@ -533,6 +542,16 @@ public class UserAccountService : IUserAccountService
             _ => 0
         };
     }
+
+    private static string GetUsageDisplayLabel(UsageType usageType, int count) =>
+        usageType switch
+        {
+            UsageType.Analysis => count == 1 ? "analysis" : "analyses",
+            UsageType.FeedQuery => count == 1 ? "feed query" : "feed queries",
+            UsageType.ReportCreated or UsageType.ReportDeleted => count == 1 ? "report" : "reports",
+            UsageType.ApiCall => count == 1 ? "API call" : "API calls",
+            _ => count == 1 ? "credit" : "credits"
+        };
 
     private static UserAccount MapEntityToModel(UserAccountEntity entity)
     {

--- a/feedbackfunctions/Services/Account/UserAccountService.cs
+++ b/feedbackfunctions/Services/Account/UserAccountService.cs
@@ -339,12 +339,27 @@ public class UserAccountService : IUserAccountService
             _ => true
         };
 
+        var currentUsage = GetCurrentUsage(user, usageType);
+        var usageLimit = GetLimitForUsageType(limits, usageType);
+        var remainingUsage = Math.Max(usageLimit - currentUsage, 0);
+        var usagePercentage = usageLimit > 0
+            ? (int)Math.Round((double)currentUsage / usageLimit * 100, MidpointRounding.AwayFromZero)
+            : 0;
+        var warningThresholdPercentage = GetConfigValue("Usage:WarningThresholdPercent", 80);
+        var isNearLimit = withinLimit && usageLimit > 0 && usagePercentage >= warningThresholdPercentage;
+
         return new UsageValidationResult 
         { 
             IsWithinLimit = withinLimit, 
             UsageType = usageType,
-            CurrentUsage = GetCurrentUsage(user, usageType),
-            Limit = GetLimitForUsageType(limits, usageType),
+            CurrentUsage = currentUsage,
+            Limit = usageLimit,
+            RemainingUsage = remainingUsage,
+            UsagePercentage = usagePercentage,
+            IsNearLimit = isNearLimit,
+            WarningMessage = isNearLimit
+                ? $"You have {remainingUsage} {usageType} usage remaining this period."
+                : null,
             CurrentTier = user.Tier,
             ResetDate = usageType == UsageType.ReportCreated ? null : user.LastResetDate.AddDays(30),
             ErrorMessage = withinLimit ? null : $"Usage limit exceeded for {usageType}",

--- a/feedbackfunctions/local.settings.json
+++ b/feedbackfunctions/local.settings.json
@@ -69,7 +69,8 @@
     },
     "Usage": {
       "ResetPeriodDays": "30",
-      "EnableTracking": "true"
+      "EnableTracking": "true",
+      "WarningThresholdPercent": "80"
     },
     "Development": {
       "UserId": "dev-user-demo",

--- a/feedbackwebapp/Components/Account/UsageDashboard.razor
+++ b/feedbackwebapp/Components/Account/UsageDashboard.razor
@@ -26,6 +26,18 @@
                 <UsageMetric Label="API Calls" Used="@UserAccount.ApiUsed" Limit="@Limits.ApiLimit" />
             }
         </div>
+        @if (IsFeedQueryNearLimit())
+        {
+            <div class="usage-warning d-flex align-items-start gap-2">
+                <i class="bi bi-exclamation-triangle-fill mt-1"></i>
+                <div>
+                    <strong>Feed query budget is running low.</strong>
+                    <div>
+                        You have @GetRemainingFeedQueries() of @Limits.FeedQueryLimit feed queries remaining this period.
+                    </div>
+                </div>
+            </div>
+        }
         @if (IsOverAnyLimit())
         {
             <UpgradePrompt />
@@ -55,5 +67,26 @@
                UserAccount.ActiveReports >= Limits.ReportLimit ||
                UserAccount.FeedQueriesUsed >= Limits.FeedQueryLimit ||
                (AccountTierUtils.SupportsApiKeyGeneration(UserAccount.Tier) && UserAccount.ApiUsed >= Limits.ApiLimit);
+    }
+
+    private int GetRemainingFeedQueries()
+    {
+        if (UserAccount is null || Limits is null)
+        {
+            return 0;
+        }
+
+        return Math.Max(Limits.FeedQueryLimit - UserAccount.FeedQueriesUsed, 0);
+    }
+
+    private bool IsFeedQueryNearLimit()
+    {
+        if (UserAccount is null || Limits is null || Limits.FeedQueryLimit <= 0)
+        {
+            return false;
+        }
+
+        var usagePercent = (double)UserAccount.FeedQueriesUsed / Limits.FeedQueryLimit * 100;
+        return usagePercent >= 80 && usagePercent < 100;
     }
 }

--- a/feedbackwebapp/Components/Account/UsageDashboard.razor
+++ b/feedbackwebapp/Components/Account/UsageDashboard.razor
@@ -2,6 +2,7 @@
 @using FeedbackWebApp.Components.Account
 @using SharedDump.Models.Account
 @using SharedDump.Utils.Account
+@inject IConfiguration Configuration
 
 <div class="usage-dashboard">
     @if (IsLoading)
@@ -87,6 +88,12 @@
         }
 
         var usagePercent = (double)UserAccount.FeedQueriesUsed / Limits.FeedQueryLimit * 100;
-        return usagePercent >= 80 && usagePercent < 100;
+        return usagePercent >= GetWarningThresholdPercent() && usagePercent < 100;
+    }
+
+    private int GetWarningThresholdPercent()
+    {
+        var configuredThreshold = Configuration["Usage:WarningThresholdPercent"];
+        return int.TryParse(configuredThreshold, out var threshold) ? threshold : 80;
     }
 }

--- a/feedbackwebapp/Components/Account/UsageDashboard.razor.css
+++ b/feedbackwebapp/Components/Account/UsageDashboard.razor.css
@@ -43,6 +43,20 @@
     margin-bottom: 1rem;
 }
 
+.usage-warning {
+    margin-bottom: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-radius-sm);
+    background: rgba(var(--warning-color-rgb), 0.12);
+    border: 1px solid rgba(var(--warning-color-rgb), 0.35);
+    color: var(--text-primary);
+    transition: color 0.3s ease, background-color 0.3s ease;
+}
+
+.usage-warning i {
+    color: var(--warning-color);
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .usage-dashboard {

--- a/shareddump/Models/Account/UsageValidationResult.cs
+++ b/shareddump/Models/Account/UsageValidationResult.cs
@@ -6,6 +6,10 @@ public class UsageValidationResult
     public UsageType UsageType { get; set; }
     public int CurrentUsage { get; set; }
     public int Limit { get; set; }
+    public int RemainingUsage { get; set; }
+    public int UsagePercentage { get; set; }
+    public bool IsNearLimit { get; set; }
+    public string? WarningMessage { get; set; }
     public AccountTier CurrentTier { get; set; }
     public string? UpgradeUrl { get; set; }
     public DateTimeOffset? ResetDate { get; set; }
@@ -15,4 +19,3 @@ public class UsageValidationResult
     public string ErrorCode { get; set; } = string.Empty;
     public string Message { get; set; } = string.Empty;
 }
-


### PR DESCRIPTION
## Summary
- add near-limit governance metadata to usage validation results (`remaining`, `usage%`, `isNearLimit`, warning message)
- compute near-limit state in `UserAccountService.ValidateUsageAsync` using configurable threshold
- add centralized near-limit observability logging during usage validation
- add feed-query near-limit warning UX to account usage dashboard with scoped, theme-safe styling
- add configurable warning threshold (`Usage:WarningThresholdPercent`) to local settings

## Validation
- dotnet build FeedbackFlow.slnx --configuration Release
- dotnet test FeedbackFlow.slnx --configuration Release

## Context
- Phase 3 governance and rollout hardening work from issue #245