### PR TITLE
[shareddump] Limit X/Twitter reply collection to a configurable maximum

### DIFF
--- a/feedbackflow.tests/TwitterFeedbackFetcherTests.cs
+++ b/feedbackflow.tests/TwitterFeedbackFetcherTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using SharedDump.Models.TwitterFeedback;
+
+namespace FeedbackFlow.Tests;
+
+[TestClass]
+public class TwitterFeedbackFetcherTests
+{
+    private QueuedHttpMessageHandler _handler = null!;
+    private HttpClient _httpClient = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _handler = new QueuedHttpMessageHandler();
+        _httpClient = new HttpClient(_handler);
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "test-token");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _httpClient.Dispose();
+    }
+
+    [TestMethod]
+    [TestCategory("TwitterFeedbackFetcher")]
+    public async Task FetchFeedbackAsync_WhenRepliesExceedCap_TruncatesAndSetsMayBeIncomplete()
+    {
+        // Arrange: cap = 3, API returns 5 replies
+        const int maxReplies = 3;
+        var fetcher = new TwitterFeedbackFetcher(
+            _httpClient,
+            NullLogger<TwitterFeedbackFetcher>.Instance,
+            maxReplies);
+
+        const string tweetId = "1234567890100"; // valid 13-digit snowflake
+        _handler.Enqueue(BuildMainTweetResponse(tweetId, tweetId));
+        _handler.Enqueue(BuildRepliesResponse(tweetId, replyCount: 5, hasNextPage: false));
+
+        // Act
+        var result = await fetcher.FetchFeedbackAsync(tweetId);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.MayBeIncomplete, "MayBeIncomplete should be true when reply cap is hit.");
+        Assert.IsNotNull(result.RateLimitInfo, "RateLimitInfo should describe the cap.");
+        StringAssert.Contains(result.RateLimitInfo, "capped", StringComparison.OrdinalIgnoreCase);
+
+        // Count all replies in the tree (they are flat before tree organization, but after tree build
+        // they are nested — count total across all nested levels)
+        var totalReplies = CountAllReplies(result.Items);
+        Assert.IsLessThanOrEqualTo(totalReplies, maxReplies,
+            $"Expected at most {maxReplies} replies but got {totalReplies}.");
+    }
+
+    [TestMethod]
+    [TestCategory("TwitterFeedbackFetcher")]
+    public async Task FetchFeedbackAsync_WhenRepliesUnderCap_DoesNotSetMayBeIncomplete()
+    {
+        // Arrange: cap = 10, API returns 3 replies
+        var fetcher = new TwitterFeedbackFetcher(
+            _httpClient,
+            NullLogger<TwitterFeedbackFetcher>.Instance,
+            maxReplies: 10);
+
+        const string tweetId = "1234567890200"; // valid 13-digit snowflake
+        _handler.Enqueue(BuildMainTweetResponse(tweetId, tweetId));
+        _handler.Enqueue(BuildRepliesResponse(tweetId, replyCount: 3, hasNextPage: false));
+
+        // Act
+        var result = await fetcher.FetchFeedbackAsync(tweetId);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.MayBeIncomplete, "MayBeIncomplete should be false when under cap.");
+        Assert.IsNull(result.RateLimitInfo, "RateLimitInfo should be null when not truncated.");
+
+        var totalReplies = CountAllReplies(result.Items);
+        Assert.AreEqual(3, totalReplies);
+    }
+
+    [TestMethod]
+    [TestCategory("TwitterFeedbackFetcher")]
+    public async Task FetchFeedbackAsync_WhenCapIsExactlyReplyCount_SetsMayBeIncomplete()
+    {
+        // When exactly at cap we can't distinguish "got all" from "stopped early",
+        // so MayBeIncomplete is conservatively set to true.
+        var fetcher = new TwitterFeedbackFetcher(
+            _httpClient,
+            NullLogger<TwitterFeedbackFetcher>.Instance,
+            maxReplies: 3);
+
+        const string tweetId = "1234567890300"; // valid 13-digit snowflake
+        _handler.Enqueue(BuildMainTweetResponse(tweetId, tweetId));
+        _handler.Enqueue(BuildRepliesResponse(tweetId, replyCount: 3, hasNextPage: false));
+
+        // Act
+        var result = await fetcher.FetchFeedbackAsync(tweetId);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.MayBeIncomplete,
+            "MayBeIncomplete should be true when reply count equals cap (conservative truncation signal).");
+
+        var totalReplies = CountAllReplies(result.Items);
+        Assert.AreEqual(3, totalReplies);
+    }
+
+    // --- Helpers ---
+
+    private static int CountAllReplies(IEnumerable<TwitterFeedbackItem> items)
+    {
+        var count = 0;
+        foreach (var item in items)
+        {
+            if (item.Replies is { Count: > 0 })
+            {
+                count += item.Replies.Count;
+                count += CountAllReplies(item.Replies);
+            }
+        }
+        return count;
+    }
+
+    private static HttpResponseMessage BuildMainTweetResponse(string tweetId, string conversationId)
+    {
+        var json = $$"""
+        {
+          "data": {
+            "id": "{{tweetId}}",
+            "author_id": "user1",
+            "conversation_id": "{{conversationId}}",
+            "created_at": "2024-01-01T00:00:00Z",
+            "text": "Root tweet {{tweetId}}"
+          },
+          "includes": {
+            "users": [
+              {"id": "user1", "name": "Test User", "username": "testuser"}
+            ]
+          }
+        }
+        """;
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static HttpResponseMessage BuildRepliesResponse(
+        string conversationId, int replyCount, bool hasNextPage)
+    {
+        var replies = new StringBuilder();
+        for (var i = 1; i <= replyCount; i++)
+        {
+            if (i > 1) replies.Append(',');
+            replies.Append($$"""
+            {
+              "id": "{{conversationId}}{{i:D3}}",
+              "author_id": "user{{i + 1}}",
+              "created_at": "2024-01-01T00:0{{i}}:00Z",
+              "text": "Reply {{i}}",
+              "referenced_tweets": [{"type": "replied_to", "id": "{{conversationId}}"}]
+            }
+            """);
+        }
+
+        var users = new StringBuilder();
+        for (var i = 1; i <= replyCount; i++)
+        {
+            if (i > 1) users.Append(',');
+            users.Append($$"""{"id": "user{{i + 1}}", "name": "User {{i + 1}}", "username": "user{{i + 1}}"}""");
+        }
+
+        var nextToken = hasNextPage ? ""","next_token": "nextpage123" """ : string.Empty;
+        var json = $$"""
+        {
+          "data": [{{replies}}],
+          "includes": {"users": [{{users}}]},
+          "meta": {"result_count": {{replyCount}}{{nextToken}}}
+        }
+        """;
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+}
+
+/// <summary>
+/// HTTP message handler that returns pre-queued responses in order.
+/// </summary>
+internal class QueuedHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _queue = new();
+
+    public void Enqueue(HttpResponseMessage response) => _queue.Enqueue(response);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (_queue.Count == 0)
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        return Task.FromResult(_queue.Dequeue());
+    }
+}

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -185,7 +185,9 @@ else
         }
         var twitterHttpClient = httpClientFactory.CreateClient("Twitter");
         twitterHttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", twitterBearerToken);
-        var twitterFetcher = new TwitterFeedbackFetcher(twitterHttpClient, Microsoft.Extensions.Logging.Abstractions.NullLogger<TwitterFeedbackFetcher>.Instance);
+        var maxRepliesConfig = configuration["Twitter:MaxReplies"];
+        var maxReplies = int.TryParse(maxRepliesConfig, out var parsed) ? parsed : 500;
+        var twitterFetcher = new TwitterFeedbackFetcher(twitterHttpClient, Microsoft.Extensions.Logging.Abstractions.NullLogger<TwitterFeedbackFetcher>.Instance, maxReplies);
         return new TwitterServiceAdapter(twitterFetcher);
     });
     

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -185,8 +185,7 @@ else
         }
         var twitterHttpClient = httpClientFactory.CreateClient("Twitter");
         twitterHttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", twitterBearerToken);
-        var maxRepliesConfig = configuration["Twitter:MaxReplies"];
-        var maxReplies = int.TryParse(maxRepliesConfig, out var parsed) ? parsed : 500;
+        var maxReplies = configuration.GetValue<int>("Twitter:MaxReplies", TwitterFeedbackFetcher.DefaultMaxReplies);
         var twitterFetcher = new TwitterFeedbackFetcher(twitterHttpClient, Microsoft.Extensions.Logging.Abstractions.NullLogger<TwitterFeedbackFetcher>.Instance, maxReplies);
         return new TwitterServiceAdapter(twitterFetcher);
     });

--- a/feedbackfunctions/local.settings.json
+++ b/feedbackfunctions/local.settings.json
@@ -19,7 +19,8 @@
       "BearerToken": "",
       "UseL2Cache": false,
       "ThreadCacheTTL": "00:05:00",
-      "ThreadL2CacheTTL": "00:30:00"
+      "ThreadL2CacheTTL": "00:30:00",
+      "MaxReplies": 500
     },
     "BlueSky": {
       "Username": "",

--- a/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
+++ b/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
@@ -20,7 +20,7 @@ public class TwitterFeedbackFetcher
     private int _currentReplySearches = 0;
     private HashSet<string> _processedTweetIds = new();
     private const int MaxRetryAttempts = 3;
-    private const int DefaultMaxReplies = 500;
+    public const int DefaultMaxReplies = 500;
     private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
 
     public TwitterFeedbackFetcher(HttpClient httpClient, ILogger<TwitterFeedbackFetcher> logger, int maxReplies = DefaultMaxReplies)

--- a/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
+++ b/shareddump/Models/TwitterFeedback/TwitterFeedbackFetcher.cs
@@ -13,17 +13,21 @@ public class TwitterFeedbackFetcher
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<TwitterFeedbackFetcher> _logger;
+    private readonly int _maxReplies;
     private bool _hitRateLimit = false;
+    private bool _hitReplyLimit = false;
     private int _maxReplySearches = 60; // Limit per 15 minutes
     private int _currentReplySearches = 0;
     private HashSet<string> _processedTweetIds = new();
     private const int MaxRetryAttempts = 3;
+    private const int DefaultMaxReplies = 500;
     private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
 
-    public TwitterFeedbackFetcher(HttpClient httpClient, ILogger<TwitterFeedbackFetcher> logger)
+    public TwitterFeedbackFetcher(HttpClient httpClient, ILogger<TwitterFeedbackFetcher> logger, int maxReplies = DefaultMaxReplies)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _maxReplies = maxReplies > 0 ? maxReplies : DefaultMaxReplies;
     }
 
     private async Task<List<TwitterFeedbackItem>> FetchRepliesRecursivelyAsync(string conversationId, string parentTweetId, string authorId, CancellationToken cancellationToken)
@@ -33,6 +37,12 @@ public class TwitterFeedbackFetcher
         {
             _hitRateLimit = true;
             _logger.LogWarning("Rate limit reached for reply searches (60 per 15 minutes). Skipping replies for {ParentTweetId}", parentTweetId);
+            return new List<TwitterFeedbackItem>();
+        }
+
+        // Check if we already hit the max replies cap
+        if (_hitReplyLimit)
+        {
             return new List<TwitterFeedbackItem>();
         }
 
@@ -171,6 +181,16 @@ public class TwitterFeedbackFetcher
                     // Add all replies to our collection
                     // They will be properly organized later in the tree structure
                     replies.Add(replyItem);
+
+                    // Check if we've hit the reply cap
+                    if (replies.Count >= _maxReplies)
+                    {
+                        _hitReplyLimit = true;
+                        _logger.LogWarning(
+                            "Reply cap of {MaxReplies} reached for conversation {ConversationId}. Stopping pagination.",
+                            _maxReplies, conversationId);
+                        break;
+                    }
                     
                     // Note: We no longer make the recursive call here, as we're getting all replies in one go
                 }
@@ -186,7 +206,7 @@ public class TwitterFeedbackFetcher
                 nextToken = null; // No more pages
             }
 
-        } while (!string.IsNullOrEmpty(nextToken) && !cancellationToken.IsCancellationRequested && !_hitRateLimit && _currentReplySearches < _maxReplySearches);
+        } while (!string.IsNullOrEmpty(nextToken) && !cancellationToken.IsCancellationRequested && !_hitRateLimit && !_hitReplyLimit && _currentReplySearches < _maxReplySearches);
 
         return replies;
     }
@@ -195,6 +215,7 @@ public class TwitterFeedbackFetcher
     {
         // Reset tracking variables
         _hitRateLimit = false;
+        _hitReplyLimit = false;
         _currentReplySearches = 0;
         _processedTweetIds.Clear();
         
@@ -297,20 +318,25 @@ public class TwitterFeedbackFetcher
             var response = new TwitterFeedbackResponse
             {
                 Items = new List<TwitterFeedbackItem> { mainTweet },
-                MayBeIncomplete = _hitRateLimit || _currentReplySearches >= _maxReplySearches,
+                MayBeIncomplete = _hitRateLimit || _currentReplySearches >= _maxReplySearches || _hitReplyLimit,
                 ProcessedTweetCount = _processedTweetIds.Count
             };
             
-            if (response.MayBeIncomplete)
+            if (_hitReplyLimit)
+            {
+                response.RateLimitInfo = $"Reply collection was capped at {_maxReplies} replies to limit API usage. The thread may have more replies not shown.";
+            }
+            else if (response.MayBeIncomplete)
             {
                 response.RateLimitInfo = $"Some replies may be missing due to Twitter API rate limits (60 reply searches per 15 minutes). Processed {_processedTweetIds.Count} unique tweets.";
             }
 
             _logger.LogInformation(
-                "Twitter thread fetch performance: processedTweetCount={ProcessedTweetCount}, replySearches={ReplySearches}, mayBeIncomplete={MayBeIncomplete}",
+                "Twitter thread fetch performance: processedTweetCount={ProcessedTweetCount}, replySearches={ReplySearches}, mayBeIncomplete={MayBeIncomplete}, hitReplyLimit={HitReplyLimit}",
                 response.ProcessedTweetCount,
                 _currentReplySearches,
-                response.MayBeIncomplete);
+                response.MayBeIncomplete,
+                _hitReplyLimit);
             return response;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

Caps the number of replies collected from a Twitter/X thread to a configurable maximum (default: **500**), preventing unbounded API calls and cost runaway on viral tweets.

## Changes

- **`TwitterFeedbackFetcher`** - Added `maxReplies` constructor parameter (default: 500). Breaks reply pagination when cap is hit and sets `MayBeIncomplete = true` with a descriptive message.
- **`local.settings.json`** - Added `Twitter:MaxReplies: 500` config key.
- **`Program.cs`** - Reads `Twitter:MaxReplies` from config and passes it to the fetcher.
- **`TwitterFeedbackFetcherTests.cs`** (new) - 3 tests covering over-cap truncation, under-cap, and exactly-at-cap behavior.

## Behavior

When the reply cap is reached, pagination stops immediately, `MayBeIncomplete = true` is set, and `RateLimitInfo` is populated with a descriptive truncation message.

Fixes #245