### PR TITLE
[feedbackflow] Disable X/Twitter feature flag

### DIFF
--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -51,6 +51,7 @@ public class FeedbackFunctions
     private readonly AuthenticationMiddleware _authMiddleware;
     private readonly IUserAccountService _userAccountService;
     private readonly ITwitterThreadCacheService _twitterThreadCacheService;
+    private readonly IFeatureGateService _featureGateService;
 
     /// <summary>
     /// Initializes a new instance of the FeedbackFunctions class
@@ -76,7 +77,8 @@ public class FeedbackFunctions
         IBlueSkyService blueSkyService,
         AuthenticationMiddleware authMiddleware,
         IUserAccountService userAccountService,
-        ITwitterThreadCacheService twitterThreadCacheService)
+        ITwitterThreadCacheService twitterThreadCacheService,
+        IFeatureGateService featureGateService)
     {
         _logger = logger;
         _githubService = githubService;
@@ -90,6 +92,7 @@ public class FeedbackFunctions
         _authMiddleware = authMiddleware;
         _userAccountService = userAccountService;
         _twitterThreadCacheService = twitterThreadCacheService;
+        _featureGateService = featureGateService;
     }
 
     /// <summary>
@@ -639,6 +642,18 @@ public class FeedbackFunctions
         var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Processing Twitter/X feedback request");
         
+        // Check if X/Twitter is enabled
+        if (!_featureGateService.IsXEnabled)
+        {
+            var disabledResponse = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+            await disabledResponse.WriteAsJsonAsync(new
+            {
+                ErrorCode = "X_FEATURE_DISABLED",
+                Message = "X/Twitter integration is currently disabled."
+            });
+            return disabledResponse;
+        }
+        
         // Authenticate the request
         var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
         if (authErrorResponse != null)
@@ -854,6 +869,11 @@ public class FeedbackFunctions
         }
         else if (SharedDump.Utils.UrlParsing.IsTwitterUrl(url))
         {
+            // Check if X/Twitter is enabled
+            if (!_featureGateService.IsXEnabled)
+            {
+                throw new InvalidOperationException("X/Twitter integration is currently disabled");
+            }
             serviceType = "twitter";
             platformData = await GetTwitterDataForAnalysis(url);
             commentsText = ConvertTwitterDataToCommentsText(platformData);

--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -641,6 +641,11 @@ public class FeedbackFunctions
     {
         var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Processing Twitter/X feedback request");
+
+        // Authenticate the request
+        var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
+        if (authErrorResponse != null)
+            return authErrorResponse;
         
         // Check if X/Twitter is enabled
         if (!_featureGateService.IsXEnabled)
@@ -653,11 +658,6 @@ public class FeedbackFunctions
             });
             return disabledResponse;
         }
-        
-        // Authenticate the request
-        var (user, authErrorResponse) = await req.AuthenticateAsync(_authMiddleware);
-        if (authErrorResponse != null)
-            return authErrorResponse;
 
         // Check if user's tier supports Twitter/X access
         var userAccount = await _userAccountService.GetUserAccountAsync(user!.UserId);
@@ -872,7 +872,13 @@ public class FeedbackFunctions
             // Check if X/Twitter is enabled
             if (!_featureGateService.IsXEnabled)
             {
-                throw new InvalidOperationException("X/Twitter integration is currently disabled");
+                var disabledResponse = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+                await disabledResponse.WriteAsJsonAsync(new
+                {
+                    ErrorCode = "X_FEATURE_DISABLED",
+                    Message = "X/Twitter integration is currently disabled."
+                });
+                return disabledResponse;
             }
             serviceType = "twitter";
             platformData = await GetTwitterDataForAnalysis(url);

--- a/feedbackfunctions/OmniSearch/OmniSearchService.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchService.cs
@@ -26,6 +26,7 @@ public class OmniSearchService
     private readonly IHackerNewsService _hackerNewsService;
     private readonly ITwitterService _twitterService;
     private readonly IBlueSkyService _blueSkyService;
+    private readonly IFeatureGateService _featureGateService;
     
     // In-memory cache for search results
     private static readonly ConcurrentDictionary<string, (OmniSearchResponse Response, DateTimeOffset CachedAt)> _cache = new();
@@ -40,7 +41,8 @@ public class OmniSearchService
         IRedditService redditService,
         IHackerNewsService hackerNewsService,
         ITwitterService twitterService,
-        IBlueSkyService blueSkyService)
+        IBlueSkyService blueSkyService,
+        IFeatureGateService featureGateService)
     {
         _logger = logger;
         _configuration = configuration;
@@ -49,6 +51,7 @@ public class OmniSearchService
         _hackerNewsService = hackerNewsService;
         _twitterService = twitterService;
         _blueSkyService = blueSkyService;
+        _featureGateService = featureGateService;
 
         // Read configuration with defaults
         _cacheTTL = TimeSpan.Parse(configuration["OmniSearch:CacheTTL"] ?? "00:05:00");
@@ -208,7 +211,9 @@ public class OmniSearchService
                 "youtube" => await SearchYouTubeAsync(request, cancellationToken),
                 "reddit" => await SearchRedditAsync(request, cancellationToken),
                 "hackernews" or "hacker news" => await SearchHackerNewsAsync(request, cancellationToken),
-                "twitter" => await SearchTwitterAsync(request, cancellationToken),
+                "twitter" => _featureGateService.IsXEnabled 
+                    ? await SearchTwitterAsync(request, cancellationToken)
+                    : new List<OmniSearchResult>(),
                 "bluesky" => await SearchBlueSkyAsync(request, cancellationToken),
                 _ => new List<OmniSearchResult>()
             };

--- a/feedbackfunctions/OmniSearch/OmniSearchService.cs
+++ b/feedbackfunctions/OmniSearch/OmniSearchService.cs
@@ -68,20 +68,26 @@ public class OmniSearchService
         CancellationToken cancellationToken = default)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var effectiveRequest = CreateEffectiveRequest(request);
+
         // Check cache first
-        var cacheKey = GenerateCacheKey(request);
+        var cacheKey = GenerateCacheKey(effectiveRequest);
         if (_cache.TryGetValue(cacheKey, out var cached))
         {
             if (DateTimeOffset.UtcNow - cached.CachedAt < _cacheTTL)
             {
-                _logger.LogInformation("Cache hit for omni-search query: {Query}", request.Query);
+                _logger.LogInformation("Cache hit for omni-search query: {Query}", effectiveRequest.Query);
                 // Still track usage even on cache hit - user is consuming the resource
-                await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+                await TrackPlatformUsageAsync(
+                    user,
+                    userAccountService,
+                    cached.Response.PlatformsSearched.Count,
+                    effectiveRequest.Query);
                 _logger.LogInformation(
                     "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
                     stopwatch.ElapsedMilliseconds,
                     true,
-                    request.Platforms.Count,
+                    cached.Response.PlatformsSearched.Count,
                     cached.Response.TotalCount);
                 return cached.Response;
             }
@@ -99,26 +105,30 @@ public class OmniSearchService
             if (_cache.TryGetValue(cacheKey, out cached) &&
                 DateTimeOffset.UtcNow - cached.CachedAt < _cacheTTL)
             {
-                await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+                await TrackPlatformUsageAsync(
+                    user,
+                    userAccountService,
+                    cached.Response.PlatformsSearched.Count,
+                    effectiveRequest.Query);
                 _logger.LogInformation(
                     "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
                     stopwatch.ElapsedMilliseconds,
                     true,
-                    request.Platforms.Count,
+                    cached.Response.PlatformsSearched.Count,
                     cached.Response.TotalCount);
                 return cached.Response;
             }
 
             _logger.LogInformation("Executing omni-search for query: {Query} across platforms: {Platforms}", 
-                request.Query, string.Join(", ", request.Platforms));
+                effectiveRequest.Query, string.Join(", ", effectiveRequest.Platforms));
 
             var results = new List<OmniSearchResult>();
             var searchTasks = new List<Task<List<OmniSearchResult>>>();
 
             // Launch platform searches in parallel
-            foreach (var platform in request.Platforms)
+            foreach (var platform in effectiveRequest.Platforms)
             {
-                searchTasks.Add(SearchPlatformAsync(platform.ToLowerInvariant(), request, cancellationToken));
+                searchTasks.Add(SearchPlatformAsync(platform.ToLowerInvariant(), effectiveRequest, cancellationToken));
             }
 
             // Wait for all platforms to complete
@@ -131,7 +141,7 @@ public class OmniSearchService
             }
 
             // Sort results (filtering for zero comments is handled on client side)
-            results = request.SortMode.ToLowerInvariant() == "ranked"
+            results = effectiveRequest.SortMode.ToLowerInvariant() == "ranked"
                 ? RankResults(results)
                 : results.OrderByDescending(r => r.CommentCount).ThenByDescending(r => r.PublishedAt).ToList();
 
@@ -146,24 +156,24 @@ public class OmniSearchService
                 Page = 1,
                 PageSize = totalCount, // PageSize equals total count
                 CachedAt = DateTimeOffset.UtcNow,
-                Query = request.Query,
-                PlatformsSearched = request.Platforms
+                Query = effectiveRequest.Query,
+                PlatformsSearched = effectiveRequest.Platforms
             };
 
             // Cache the response
             _cache[cacheKey] = (response, DateTimeOffset.UtcNow);
         
             _logger.LogInformation("Omni-search completed. Found {Count} total results across {PlatformCount} platforms", 
-                totalCount, request.Platforms.Count);
+                totalCount, effectiveRequest.Platforms.Count);
 
             // Track usage - one credit per platform searched
-            await TrackPlatformUsageAsync(user, userAccountService, request.Platforms.Count, request.Query);
+            await TrackPlatformUsageAsync(user, userAccountService, effectiveRequest.Platforms.Count, effectiveRequest.Query);
 
             _logger.LogInformation(
                 "OmniSearch performance: totalMs={TotalMs}, cacheHit={CacheHit}, platformCount={PlatformCount}, resultCount={ResultCount}",
                 stopwatch.ElapsedMilliseconds,
                 false,
-                request.Platforms.Count,
+                effectiveRequest.Platforms.Count,
                 totalCount);
 
             return response;
@@ -184,6 +194,12 @@ public class OmniSearchService
         int platformCount,
         string query)
     {
+        if (platformCount <= 0)
+        {
+            _logger.LogInformation("No searchable platforms selected for query {Query}; skipping usage tracking", query);
+            return;
+        }
+
         try
         {
             // Track usage for each platform (amount = platformCount)
@@ -200,6 +216,29 @@ public class OmniSearchService
             _logger.LogError(ex, "Error tracking usage for user {UserId}", user.UserId);
             // Don't throw - tracking failures shouldn't break the search
         }
+    }
+
+    private OmniSearchRequest CreateEffectiveRequest(OmniSearchRequest request)
+    {
+        var platforms = request.Platforms;
+
+        if (!_featureGateService.IsXEnabled)
+        {
+            platforms = request.Platforms
+                .Where(platform => !platform.Equals("twitter", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        return new OmniSearchRequest
+        {
+            Query = request.Query,
+            Platforms = platforms,
+            FromDate = request.FromDate,
+            ToDate = request.ToDate,
+            MaxResults = request.MaxResults,
+            SortMode = request.SortMode,
+            Page = request.Page
+        };
     }
 
     private async Task<List<OmniSearchResult>> SearchPlatformAsync(string platform, OmniSearchRequest request, CancellationToken cancellationToken)

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -90,6 +90,7 @@ if (useMocks)
     builder.Services.AddScoped<ITwitterService, MockTwitterService>();
     builder.Services.AddScoped<IBlueSkyService, MockBlueSkyService>();
     builder.Services.AddScoped<IEmailService, MockEmailService>();
+    builder.Services.AddScoped<IFeatureGateService, FeatureGateService>();
 }
 else
 {
@@ -268,6 +269,7 @@ void RegisterStorageServices(IServiceCollection services)
     services.AddSingleton<FeedbackStorageClients>();
     services.AddSingleton<ITableInitializationService, TableInitializationService>();
     services.AddSingleton<IReportStorageService, ReportStorageService>();
+    services.AddScoped<IFeatureGateService, FeatureGateService>();
 }
 
 void RegisterAccountServices(IServiceCollection services)

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -90,7 +90,6 @@ if (useMocks)
     builder.Services.AddScoped<ITwitterService, MockTwitterService>();
     builder.Services.AddScoped<IBlueSkyService, MockBlueSkyService>();
     builder.Services.AddScoped<IEmailService, MockEmailService>();
-    builder.Services.AddScoped<IFeatureGateService, FeatureGateService>();
 }
 else
 {

--- a/feedbackfunctions/local.settings.json
+++ b/feedbackfunctions/local.settings.json
@@ -82,6 +82,11 @@
       "CacheTTL": "00:05:00",
       "MaxConcurrencyPerPlatform": "4"
     },
+    "Features": {
+      "X": {
+        "Enabled": false
+      }
+    },
     "WebUrl": "https://www.feedbackflow.app"
   }
 }

--- a/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
+++ b/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
@@ -2,8 +2,10 @@
 @using SharedDump.Utils.Account
 @using SharedDump.Models.Account
 @using FeedbackWebApp.Services.Account
+@using SharedDump.Services.Interfaces
 @inject IAccountServiceProvider AccountServiceProvider
 @inject Microsoft.JSInterop.IJSRuntime JSRuntime
+@inject IFeatureGateService FeatureGateService
 
 <div class="omni-search-form">
     <div class="mb-3">
@@ -49,21 +51,24 @@
                     <i class="bi bi-newspaper text-warning"></i> Hacker News
                 </label>
             </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" 
-                       type="checkbox" 
-                       id="platform-twitter" 
-                       @bind="EnableTwitter"
-                       @bind:after="UpdateUsageCount"
-                       disabled="@(!canUseTwitter)" />
-                <label class="form-check-label" for="platform-twitter">
-                    <i class="bi bi-twitter-x"></i> Twitter
-                    @if (!canUseTwitter)
-                    {
-                        <span class="badge bg-warning ms-1" title="Pro account required">Pro</span>
-                    }
-                </label>
-            </div>
+            @if (isXEnabled)
+            {
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" 
+                           type="checkbox" 
+                           id="platform-twitter" 
+                           @bind="EnableTwitter"
+                           @bind:after="UpdateUsageCount"
+                           disabled="@(!canUseTwitter)" />
+                    <label class="form-check-label" for="platform-twitter">
+                        <i class="bi bi-twitter-x"></i> Twitter
+                        @if (!canUseTwitter)
+                        {
+                            <span class="badge bg-warning ms-1" title="Pro account required">Pro</span>
+                        }
+                    </label>
+                </div>
+            }
             <div class="form-check form-check-inline">
                 <input class="form-check-input" 
                        type="checkbox" 
@@ -149,6 +154,7 @@
     public DateTime? FromDate { get; set; }
     public DateTime? ToDate { get; set; }
 
+    private bool isXEnabled = false;
     private bool canUseTwitter = false;
     private (UserAccount? account, AccountLimits limits)? accountLimits;
     private int currentUsage = 0;
@@ -156,6 +162,9 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // Check if X/Twitter is enabled
+        isXEnabled = FeatureGateService.IsXEnabled;
+
         // Check if user can access Twitter and get account limits
         var accountService = AccountServiceProvider.GetService();
         accountLimits = await accountService.GetUserAccountAndLimitsAsync();
@@ -186,7 +195,7 @@
         if (EnableYouTube) platforms.Add("youtube");
         if (EnableReddit) platforms.Add("reddit");
         if (EnableHackerNews) platforms.Add("hackernews");
-        if (EnableTwitter && canUseTwitter) platforms.Add("twitter");
+        if (EnableTwitter && canUseTwitter && isXEnabled) platforms.Add("twitter");
         if (EnableBlueSky) platforms.Add("bluesky");
         return platforms;
     }
@@ -228,9 +237,13 @@
             if (bool.TryParse(hn, out var enableHN))
                 EnableHackerNews = enableHN;
 
-            var twitter = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_twitter");
-            if (bool.TryParse(twitter, out var enableTwitter))
-                EnableTwitter = enableTwitter;
+            // Only load Twitter preference if X is enabled
+            if (isXEnabled)
+            {
+                var twitter = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_twitter");
+                if (bool.TryParse(twitter, out var enableTwitter))
+                    EnableTwitter = enableTwitter;
+            }
 
             var bluesky = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_bluesky");
             if (bool.TryParse(bluesky, out var enableBlueSky))

--- a/feedbackwebapp/Components/ContentFeed/Results/OmniSearchResults.razor
+++ b/feedbackwebapp/Components/ContentFeed/Results/OmniSearchResults.razor
@@ -1,6 +1,8 @@
 @namespace FeedbackWebApp.Components.ContentFeed.Results
 @using SharedDump.Models.ContentSearch
+@using SharedDump.Services.Interfaces
 @inject NavigationManager Navigation
+@inject IFeatureGateService FeatureGateService
 
 <div class="omni-search-results">
     @if (Response is not null)

--- a/feedbackwebapp/Components/ContentFeed/Results/OmniSearchResults.razor
+++ b/feedbackwebapp/Components/ContentFeed/Results/OmniSearchResults.razor
@@ -1,8 +1,6 @@
 @namespace FeedbackWebApp.Components.ContentFeed.Results
 @using SharedDump.Models.ContentSearch
-@using SharedDump.Services.Interfaces
 @inject NavigationManager Navigation
-@inject IFeatureGateService FeatureGateService
 
 <div class="omni-search-results">
     @if (Response is not null)

--- a/feedbackwebapp/Components/ContentFeed/Results/SelectedItemsSidebar.razor
+++ b/feedbackwebapp/Components/ContentFeed/Results/SelectedItemsSidebar.razor
@@ -1,5 +1,7 @@
 @namespace FeedbackWebApp.Components.ContentFeed.Results
 @using FeedbackWebApp.Components.Pages
+@using SharedDump.Services.Interfaces
+@inject IFeatureGateService FeatureGateService
 
 <div class="selected-items-sidebar @(isCollapsed ? "collapsed" : "expanded")">
     <div class="sidebar-header" @onclick="ToggleCollapse">
@@ -38,7 +40,7 @@
                 </div>
 
                 <div class="selected-items-list">
-                    @foreach (var item in SelectedItems)
+                    @foreach (var item in GetVisibleItems())
                     {
                         <div class="selected-item-card">
                             <div class="d-flex gap-2">
@@ -148,5 +150,18 @@
         {
             return url.Length > 40 ? url.Substring(0, 40) + "..." : url;
         }
+    }
+
+    private List<ContentFeeds.SelectedItem> GetVisibleItems()
+    {
+        // Filter out Twitter items if X is disabled
+        if (FeatureGateService.IsXEnabled)
+        {
+            return SelectedItems;
+        }
+        
+        return SelectedItems
+            .Where(item => !item.SourceType.Equals("twitter", StringComparison.OrdinalIgnoreCase))
+            .ToList();
     }
 }

--- a/feedbackwebapp/Components/ContentFeed/Results/SelectedItemsSidebar.razor
+++ b/feedbackwebapp/Components/ContentFeed/Results/SelectedItemsSidebar.razor
@@ -8,7 +8,7 @@
         <div class="d-flex align-items-center justify-content-between">
             <h5 class="mb-0">
                 <i class="bi bi-collection me-2"></i>
-                Selected Items (@SelectedItems.Count/@MaxItems)
+                Selected Items (@GetVisibleItemCount()/@MaxItems)
             </h5>
             <button class="btn btn-sm btn-link text-decoration-none" aria-label="@(isCollapsed ? "Expand" : "Collapse")">
                 <i class="bi bi-@(isCollapsed ? "chevron-left" : "chevron-right")"></i>
@@ -19,7 +19,10 @@
     @if (!isCollapsed)
     {
         <div class="sidebar-body">
-            @if (SelectedItems.Any())
+            @{
+                var visibleItems = GetVisibleItems();
+            }
+            @if (visibleItems.Any())
             {
                 <div class="mb-3">
                     <button class="btn btn-primary w-100 mb-2" @onclick="OnAnalyzeClick" disabled="@IsAnalyzing">
@@ -40,7 +43,7 @@
                 </div>
 
                 <div class="selected-items-list">
-                    @foreach (var item in GetVisibleItems())
+                    @foreach (var item in visibleItems)
                     {
                         <div class="selected-item-card">
                             <div class="d-flex gap-2">
@@ -152,7 +155,7 @@
         }
     }
 
-    private List<ContentFeeds.SelectedItem> GetVisibleItems()
+    private IEnumerable<ContentFeeds.SelectedItem> GetVisibleItems()
     {
         // Filter out Twitter items if X is disabled
         if (FeatureGateService.IsXEnabled)
@@ -160,8 +163,13 @@
             return SelectedItems;
         }
         
-        return SelectedItems
-            .Where(item => !item.SourceType.Equals("twitter", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        return SelectedItems.Where(item => !item.SourceType.Equals("twitter", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private int GetVisibleItemCount()
+    {
+        return FeatureGateService.IsXEnabled
+            ? SelectedItems.Count
+            : SelectedItems.Count(item => !item.SourceType.Equals("twitter", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/feedbackwebapp/Components/Feedback/PlatformPills.razor
+++ b/feedbackwebapp/Components/Feedback/PlatformPills.razor
@@ -20,17 +20,17 @@
 @code {
     private List<PlatformOption> supportedPlatforms = new();
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         var allPlatforms = new[]
         {
-            new PlatformOption("YouTube", "bi-youtube", "#FF0000"),
-            new PlatformOption("GitHub", "bi-github", "#333333"),
-            new PlatformOption("Reddit", "bi-reddit", "#FF4500"),
-            new PlatformOption("HackerNews", "bi-braces", "#FF6600"),
-            new PlatformOption("DevBlogs", "bi-journal-richtext", "#0078D4"),
-            new PlatformOption("Twitter", "bi-twitter-x", "#1DA1F2"),
-            new PlatformOption("BlueSky", "bi-cloud-fill", "#00A8E8")
+            new PlatformOption("YouTube", "bi-youtube"),
+            new PlatformOption("GitHub", "bi-github"),
+            new PlatformOption("Reddit", "bi-reddit"),
+            new PlatformOption("HackerNews", "bi-braces"),
+            new PlatformOption("DevBlogs", "bi-journal-richtext"),
+            new PlatformOption("Twitter", "bi-twitter-x"),
+            new PlatformOption("BlueSky", "bi-cloud-fill")
         };
 
         // Filter out Twitter if X is disabled
@@ -42,9 +42,7 @@
         {
             supportedPlatforms = allPlatforms.Where(p => p.Name != "Twitter").ToList();
         }
-
-        await base.OnInitializedAsync();
     }
 
-    private record PlatformOption(string Name, string IconClass, string Color);
+    private record PlatformOption(string Name, string IconClass);
 }

--- a/feedbackwebapp/Components/Feedback/PlatformPills.razor
+++ b/feedbackwebapp/Components/Feedback/PlatformPills.razor
@@ -1,4 +1,6 @@
 @namespace FeedbackWebApp.Components.Feedback
+@using SharedDump.Services.Interfaces
+@inject IFeatureGateService FeatureGateService
 
 <div class="platform-pills-container mt-4">
     <div class="text-center mb-3">
@@ -16,16 +18,33 @@
 </div>
 
 @code {
-    private readonly PlatformOption[] supportedPlatforms = new[]
+    private List<PlatformOption> supportedPlatforms = new();
+
+    protected override async Task OnInitializedAsync()
     {
-        new PlatformOption("YouTube", "bi-youtube", "#FF0000"),
-        new PlatformOption("GitHub", "bi-github", "#333333"),
-        new PlatformOption("Reddit", "bi-reddit", "#FF4500"),
-        new PlatformOption("HackerNews", "bi-braces", "#FF6600"),
-        new PlatformOption("DevBlogs", "bi-journal-richtext", "#0078D4"),
-        new PlatformOption("Twitter", "bi-twitter-x", "#1DA1F2"),
-        new PlatformOption("BlueSky", "bi-cloud-fill", "#00A8E8")
-    };
+        var allPlatforms = new[]
+        {
+            new PlatformOption("YouTube", "bi-youtube", "#FF0000"),
+            new PlatformOption("GitHub", "bi-github", "#333333"),
+            new PlatformOption("Reddit", "bi-reddit", "#FF4500"),
+            new PlatformOption("HackerNews", "bi-braces", "#FF6600"),
+            new PlatformOption("DevBlogs", "bi-journal-richtext", "#0078D4"),
+            new PlatformOption("Twitter", "bi-twitter-x", "#1DA1F2"),
+            new PlatformOption("BlueSky", "bi-cloud-fill", "#00A8E8")
+        };
+
+        // Filter out Twitter if X is disabled
+        if (FeatureGateService.IsXEnabled)
+        {
+            supportedPlatforms = allPlatforms.ToList();
+        }
+        else
+        {
+            supportedPlatforms = allPlatforms.Where(p => p.Name != "Twitter").ToList();
+        }
+
+        await base.OnInitializedAsync();
+    }
 
     private record PlatformOption(string Name, string IconClass, string Color);
 }

--- a/feedbackwebapp/Components/Pages/History.razor
+++ b/feedbackwebapp/Components/Pages/History.razor
@@ -7,6 +7,7 @@
 @inject FeedbackWebApp.Services.IToastService ToastService
 @inject FeedbackWebApp.Services.IHistoryHelper HistoryHelper
 @inject FeedbackWebApp.Services.UserSettingsService UserSettings
+@inject SharedDump.Services.Interfaces.IFeatureGateService FeatureGateService
 @using SharedDump.Models
 @using Markdig
 @using Microsoft.JSInterop
@@ -14,6 +15,7 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using FeedbackWebApp.Services.Interfaces
 @using SharedDump.Utils
+@using SharedDump.Services.Interfaces
 @using FeedbackWebApp.Utils
 @using FeedbackWebApp.Services
 @using FeedbackWebApp.Components.Shared
@@ -103,7 +105,10 @@
                             <option value="YouTube">YouTube</option>
                             <option value="GitHub">GitHub</option>
                             <option value="Reddit">Reddit</option>
-                            <option value="Twitter">Twitter</option>
+                            @if (FeatureGateService.IsXEnabled)
+                            {
+                                <option value="Twitter">Twitter</option>
+                            }
                             <option value="HackerNews">HackerNews</option>
                             <option value="DevBlogs">DevBlogs</option>
                             <option value="Manual">Manual</option>

--- a/feedbackwebapp/Components/Pages/History.razor
+++ b/feedbackwebapp/Components/Pages/History.razor
@@ -7,7 +7,7 @@
 @inject FeedbackWebApp.Services.IToastService ToastService
 @inject FeedbackWebApp.Services.IHistoryHelper HistoryHelper
 @inject FeedbackWebApp.Services.UserSettingsService UserSettings
-@inject SharedDump.Services.Interfaces.IFeatureGateService FeatureGateService
+@inject IFeatureGateService FeatureGateService
 @using SharedDump.Models
 @using Markdig
 @using Microsoft.JSInterop

--- a/feedbackwebapp/Components/Pages/HistoryLocal.razor
+++ b/feedbackwebapp/Components/Pages/HistoryLocal.razor
@@ -5,7 +5,7 @@
 @inject NavigationManager NavigationManager
 @inject FeedbackWebApp.Services.IToastService ToastService
 @inject FeedbackWebApp.Services.IHistoryHelper HistoryHelper
-@inject SharedDump.Services.Interfaces.IFeatureGateService FeatureGateService
+@inject IFeatureGateService FeatureGateService
 @using SharedDump.Models
 @using Markdig
 @using Microsoft.JSInterop

--- a/feedbackwebapp/Components/Pages/HistoryLocal.razor
+++ b/feedbackwebapp/Components/Pages/HistoryLocal.razor
@@ -5,12 +5,14 @@
 @inject NavigationManager NavigationManager
 @inject FeedbackWebApp.Services.IToastService ToastService
 @inject FeedbackWebApp.Services.IHistoryHelper HistoryHelper
+@inject SharedDump.Services.Interfaces.IFeatureGateService FeatureGateService
 @using SharedDump.Models
 @using Markdig
 @using Microsoft.JSInterop
 @using Microsoft.AspNetCore.Components
 @using FeedbackWebApp.Components.Shared
 @using SharedDump.Utils
+@using SharedDump.Services.Interfaces
 @using FeedbackWebApp.Utils
 @using FeedbackWebApp.Services
 
@@ -76,7 +78,10 @@
                         <option value="YouTube">YouTube</option>
                         <option value="GitHub">GitHub</option>
                         <option value="Reddit">Reddit</option>
-                        <option value="Twitter">Twitter</option>
+                        @if (FeatureGateService.IsXEnabled)
+                        {
+                            <option value="Twitter">Twitter</option>
+                        }
                         <option value="HackerNews">HackerNews</option>
                         <option value="DevBlogs">DevBlogs</option>
                         <option value="Manual">Manual</option>

--- a/feedbackwebapp/Components/Pages/Home.razor
+++ b/feedbackwebapp/Components/Pages/Home.razor
@@ -22,6 +22,7 @@
 @using SharedDump.Models.YouTube
 @using SharedDump.Utils
 @using SharedDump.Services
+@using SharedDump.Services.Interfaces
 @using SharedDump.AI
 
 @inject IConfiguration Configuration
@@ -33,6 +34,7 @@
 @inject IAuthenticationService AuthService
 @inject IRegistrationErrorService RegistrationErrorService
 @inject ITwitterAccessService TwitterAccessService
+@inject IFeatureGateService FeatureGateService
 @implements IDisposable
 
 <PageTitle>Feedback Analysis - FeedbackFlow</PageTitle>
@@ -448,9 +450,10 @@
         .OrderBy(u => u)
         .ToArray();
 
-    private static string NormalizeUrlForComparison(string url)
+    private string NormalizeUrlForComparison(string url)
     {
-        if (UrlParsing.IsTwitterUrl(url))
+        // Only process Twitter URLs if X is enabled
+        if (FeatureGateService.IsXEnabled && UrlParsing.IsTwitterUrl(url))
         {
             var tweetId = TwitterUrlParser.ExtractTweetId(url);
             if (!string.IsNullOrWhiteSpace(tweetId))

--- a/feedbackwebapp/Program.cs
+++ b/feedbackwebapp/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddMemoryCache();
 // Register ToastService and other services
 builder.Services.AddScoped<IToastService, ToastService>();
 builder.Services.AddScoped<IHistoryHelper, HistoryHelper>();
+builder.Services.AddScoped<IFeatureGateService, FeatureGateService>();
 
 builder.Services.AddHttpClient("DefaultClient")
     .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(3));

--- a/shareddump/Services/FeatureGateService.cs
+++ b/shareddump/Services/FeatureGateService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+using SharedDump.Services.Interfaces;
+
+namespace SharedDump.Services;
+
+/// <summary>
+/// Service for checking feature availability based on configuration flags.
+/// </summary>
+public class FeatureGateService : IFeatureGateService
+{
+    private readonly IConfiguration _configuration;
+
+    public FeatureGateService(IConfiguration configuration)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public bool IsXEnabled
+    {
+        get
+        {
+            var value = _configuration["Features:X:Enabled"];
+            return bool.TryParse(value, out var result) && result;
+        }
+    }
+}

--- a/shareddump/Services/Interfaces/IFeatureGateService.cs
+++ b/shareddump/Services/Interfaces/IFeatureGateService.cs
@@ -1,0 +1,12 @@
+namespace SharedDump.Services.Interfaces;
+
+/// <summary>
+/// Service for checking feature availability based on configuration flags.
+/// </summary>
+public interface IFeatureGateService
+{
+    /// <summary>
+    /// Checks if X/Twitter integration is enabled.
+    /// </summary>
+    bool IsXEnabled { get; }
+}


### PR DESCRIPTION
Implement feature flag infrastructure to disable X/Twitter integration entirely.

## Overview
This PR adds a comprehensive feature flag system for X/Twitter integration, disabled by default.

## Changes

### Backend Infrastructure
- Created `IFeatureGateService` interface and `FeatureGateService` implementation
- Service reads `Features:X:Enabled` config (defaults false)
- Safe bool parsing for config with fallback to false
- Registered in both web app and functions DI containers

### API Endpoints
- `FeedbackFunctions.GetTwitterFeedback` - Returns 503 ServiceUnavailable when disabled
- `FeedbackFunctions.AutoAnalyze` - Returns 503 ServiceUnavailable for Twitter URLs when disabled
- `OmniSearchService.SearchAsync` - Filters Twitter from effective search platforms when disabled

### UI Components
- `PlatformPills.razor` - Hide Twitter from supported platforms
- `OmniSearchForm.razor` - Hide/disable Twitter checkbox
- `Home.razor` - Skip Twitter URL normalization
- `History.razor` - Hide Twitter filter option
- `HistoryLocal.razor` - Hide Twitter filter option
- `SelectedItemsSidebar.razor` - Filter/hide Twitter items

### Configuration
- `local.settings.json` updated with `Features:X:Enabled: false`
- Environment variable override: `FEATURES__X__ENABLED`