### PR TITLE
Add feature flag to disable Twitter on search page

### DIFF
--- a/FeedbackFlow.AppHost/appsettings.json
+++ b/FeedbackFlow.AppHost/appsettings.json
@@ -7,8 +7,8 @@
     }
   },
   "Features": {
-    "Twitter": {
-      "DisableOnSearchPage": false
+    "X": {
+      "DisableOnSearchPage": true
     }
   }
 }

--- a/FeedbackFlow.AppHost/appsettings.json
+++ b/FeedbackFlow.AppHost/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "Features": {
+    "Twitter": {
+      "DisableOnSearchPage": false
+    }
   }
 }

--- a/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
+++ b/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
@@ -51,7 +51,7 @@
                     <i class="bi bi-newspaper text-warning"></i> Hacker News
                 </label>
             </div>
-            @if (isXEnabled && !disableTwitterOnSearchPage)
+            @if (isXEnabled && !disableXOnSearchPage)
             {
                 <div class="form-check form-check-inline">
                     <input class="form-check-input" 
@@ -159,16 +159,16 @@
     private (UserAccount? account, AccountLimits limits)? accountLimits;
     private int currentUsage = 0;
     private int selectedPlatformCount = 0;
-    private bool disableTwitterOnSearchPage = false;
+    private bool disableXOnSearchPage = false;
 
     protected override async Task OnInitializedAsync()
     {
         // Check if X/Twitter is enabled
         isXEnabled = FeatureGateService.IsXEnabled;
 
-        // Check if Twitter is disabled specifically for the search page
-        disableTwitterOnSearchPage = FeatureGateService.IsTwitterDisabledOnSearchPage;
-        if (disableTwitterOnSearchPage)
+        // Check if X/Twitter is disabled specifically for the search page
+        disableXOnSearchPage = FeatureGateService.IsXDisabledOnSearchPage;
+        if (disableXOnSearchPage)
         {
             EnableTwitter = false;
         }
@@ -203,7 +203,7 @@
         if (EnableYouTube) platforms.Add("youtube");
         if (EnableReddit) platforms.Add("reddit");
         if (EnableHackerNews) platforms.Add("hackernews");
-        if (EnableTwitter && canUseTwitter && isXEnabled && !disableTwitterOnSearchPage) platforms.Add("twitter");
+        if (EnableTwitter && canUseTwitter && isXEnabled && !disableXOnSearchPage) platforms.Add("twitter");
         if (EnableBlueSky) platforms.Add("bluesky");
         return platforms;
     }
@@ -246,7 +246,7 @@
                 EnableHackerNews = enableHN;
 
             // Only load Twitter preference if X is enabled for this page.
-            if (isXEnabled && !disableTwitterOnSearchPage)
+            if (isXEnabled && !disableXOnSearchPage)
             {
                 var twitter = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_twitter");
                 if (bool.TryParse(twitter, out var enableTwitter))

--- a/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
+++ b/feedbackwebapp/Components/ContentFeed/Forms/OmniSearchForm.razor
@@ -51,7 +51,7 @@
                     <i class="bi bi-newspaper text-warning"></i> Hacker News
                 </label>
             </div>
-            @if (isXEnabled)
+            @if (isXEnabled && !disableTwitterOnSearchPage)
             {
                 <div class="form-check form-check-inline">
                     <input class="form-check-input" 
@@ -159,11 +159,19 @@
     private (UserAccount? account, AccountLimits limits)? accountLimits;
     private int currentUsage = 0;
     private int selectedPlatformCount = 0;
+    private bool disableTwitterOnSearchPage = false;
 
     protected override async Task OnInitializedAsync()
     {
         // Check if X/Twitter is enabled
         isXEnabled = FeatureGateService.IsXEnabled;
+
+        // Check if Twitter is disabled specifically for the search page
+        disableTwitterOnSearchPage = FeatureGateService.IsTwitterDisabledOnSearchPage;
+        if (disableTwitterOnSearchPage)
+        {
+            EnableTwitter = false;
+        }
 
         // Check if user can access Twitter and get account limits
         var accountService = AccountServiceProvider.GetService();
@@ -195,7 +203,7 @@
         if (EnableYouTube) platforms.Add("youtube");
         if (EnableReddit) platforms.Add("reddit");
         if (EnableHackerNews) platforms.Add("hackernews");
-        if (EnableTwitter && canUseTwitter && isXEnabled) platforms.Add("twitter");
+        if (EnableTwitter && canUseTwitter && isXEnabled && !disableTwitterOnSearchPage) platforms.Add("twitter");
         if (EnableBlueSky) platforms.Add("bluesky");
         return platforms;
     }
@@ -237,12 +245,16 @@
             if (bool.TryParse(hn, out var enableHN))
                 EnableHackerNews = enableHN;
 
-            // Only load Twitter preference if X is enabled
-            if (isXEnabled)
+            // Only load Twitter preference if X is enabled for this page.
+            if (isXEnabled && !disableTwitterOnSearchPage)
             {
                 var twitter = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_twitter");
                 if (bool.TryParse(twitter, out var enableTwitter))
                     EnableTwitter = enableTwitter;
+            }
+            else
+            {
+                EnableTwitter = false;
             }
 
             var bluesky = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "omniSearch_bluesky");

--- a/feedbackwebapp/appsettings.json
+++ b/feedbackwebapp/appsettings.json
@@ -36,8 +36,8 @@
     "Url": "https://forms.microsoft.com/r/E9qW97wtmx"
   },
   "Features": {
-    "Twitter": {
-      "DisableOnSearchPage": false
+    "X": {
+      "DisableOnSearchPage": true
     }
   }
 }

--- a/feedbackwebapp/appsettings.json
+++ b/feedbackwebapp/appsettings.json
@@ -34,5 +34,10 @@
     "Enabled": true,
     "Id": "feedback-v1",
     "Url": "https://forms.microsoft.com/r/E9qW97wtmx"
+  },
+  "Features": {
+    "Twitter": {
+      "DisableOnSearchPage": false
+    }
   }
 }

--- a/shareddump/Services/FeatureGateService.cs
+++ b/shareddump/Services/FeatureGateService.cs
@@ -23,4 +23,13 @@ public class FeatureGateService : IFeatureGateService
             return bool.TryParse(value, out var result) && result;
         }
     }
+
+    public bool IsTwitterDisabledOnSearchPage
+    {
+        get
+        {
+            var value = _configuration["Features:Twitter:DisableOnSearchPage"];
+            return bool.TryParse(value, out var result) && result;
+        }
+    }
 }

--- a/shareddump/Services/FeatureGateService.cs
+++ b/shareddump/Services/FeatureGateService.cs
@@ -24,11 +24,11 @@ public class FeatureGateService : IFeatureGateService
         }
     }
 
-    public bool IsTwitterDisabledOnSearchPage
+    public bool IsXDisabledOnSearchPage
     {
         get
         {
-            var value = _configuration["Features:Twitter:DisableOnSearchPage"];
+            var value = _configuration["Features:X:DisableOnSearchPage"];
             return bool.TryParse(value, out var result) && result;
         }
     }

--- a/shareddump/Services/Interfaces/IFeatureGateService.cs
+++ b/shareddump/Services/Interfaces/IFeatureGateService.cs
@@ -9,4 +9,9 @@ public interface IFeatureGateService
     /// Checks if X/Twitter integration is enabled.
     /// </summary>
     bool IsXEnabled { get; }
+
+    /// <summary>
+    /// Checks if Twitter should be disabled on the omni search page.
+    /// </summary>
+    bool IsTwitterDisabledOnSearchPage { get; }
 }

--- a/shareddump/Services/Interfaces/IFeatureGateService.cs
+++ b/shareddump/Services/Interfaces/IFeatureGateService.cs
@@ -11,7 +11,7 @@ public interface IFeatureGateService
     bool IsXEnabled { get; }
 
     /// <summary>
-    /// Checks if Twitter should be disabled on the omni search page.
+    /// Checks if X/Twitter should be disabled on the omni search page.
     /// </summary>
-    bool IsTwitterDisabledOnSearchPage { get; }
+    bool IsXDisabledOnSearchPage { get; }
 }


### PR DESCRIPTION
Introduce a feature flag that allows disabling Twitter specifically on the search page. This change includes updates to configuration, feature gate service, and relevant UI logic to respect the new flag.