### PR TITLE
Implement Mastodon service integration with search and thread retrieval functionality

### DIFF
--- a/feedbackfunctions/Functions/MastodonFunctions.cs
+++ b/feedbackfunctions/Functions/MastodonFunctions.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using SharedDump.Services;
+using SharedDump.Models;
+
+namespace FeedbackFunctions.Functions;
+
+public class MastodonFunctions
+{
+    private readonly IMastodonService _mastodonService;
+    private readonly ILogger<MastodonFunctions> _logger;
+
+    public MastodonFunctions(IMastodonService mastodonService, ILogger<MastodonFunctions> logger)
+    {
+        _mastodonService = mastodonService;
+        _logger = logger;
+    }
+
+    [Function("MastodonSearch")]
+    public async Task<HttpResponseData> SearchAsync(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "mastodon/search")] HttpRequestData req)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query).Get("q") ?? string.Empty;
+        var instance = System.Web.HttpUtility.ParseQueryString(req.Url.Query).Get("instance") ?? "mastodon.social";
+        try
+        {
+            var results = await _mastodonService.SearchAsync(query, instance);
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(results);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error searching Mastodon");
+            var errorResponse = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await errorResponse.WriteStringAsync("Error searching Mastodon");
+            return errorResponse;
+        }
+    }
+
+    [Function("MastodonThread")]
+    public async Task<HttpResponseData> GetThreadAsync(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "mastodon/thread")] HttpRequestData req)
+    {
+        var url = System.Web.HttpUtility.ParseQueryString(req.Url.Query).Get("url") ?? string.Empty;
+        var instance = System.Web.HttpUtility.ParseQueryString(req.Url.Query).Get("instance") ?? "mastodon.social";
+        try
+        {
+            var thread = await _mastodonService.GetThreadAsync(url, instance);
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(thread);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching Mastodon thread");
+            var errorResponse = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await errorResponse.WriteStringAsync("Error fetching Mastodon thread");
+            return errorResponse;
+        }
+    }
+}

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -90,9 +90,18 @@ if (useMocks)
     builder.Services.AddScoped<ITwitterService, MockTwitterService>();
     builder.Services.AddScoped<IBlueSkyService, MockBlueSkyService>();
     builder.Services.AddScoped<IEmailService, MockEmailService>();
+
+    // Mastodon mock service registration
+    builder.Services.AddScoped<IMastodonService, MockMastodonService>();
 }
 else
 {
+        builder.Services.AddScoped<IMastodonService>(serviceProvider =>
+        {
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            var logger = serviceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<MastodonServiceAdapter>>();
+            return new MastodonServiceAdapter(httpClientFactory.CreateClient("Mastodon"), logger);
+        });
     builder.Services.AddScoped<IGitHubService>(serviceProvider =>
     {
         var configuration = GetConfig(serviceProvider);

--- a/feedbackwebapp/Services/Feedback/FeedbackServiceProvider.cs
+++ b/feedbackwebapp/Services/Feedback/FeedbackServiceProvider.cs
@@ -1,3 +1,9 @@
+    public IMastodonFeedbackService CreateMastodonService(string statusUrlOrQuery, string instance, FeedbackStatusUpdate? onStatusUpdate = null)
+    {
+        return _useMocks
+            ? new MockMastodonFeedbackService(_http, _configuration, _authHeaderService)
+            : new MastodonFeedbackService(_http, _configuration, _authHeaderService);
+    }
 using FeedbackWebApp.Services.Interfaces;
 using FeedbackWebApp.Services.Mock;
 using FeedbackWebApp.Services.Authentication;
@@ -146,6 +152,13 @@ public class FeedbackServiceProvider
         // Dev.to or Microsoft DevBlogs URLs
         if (UrlParsing.IsDevBlogsUrl(url))
             return CreateDevBlogsService(url);
+
+        // Mastodon URLs
+        if (SharedDump.Utils.UrlParsing.IsMastodonUrl(url))
+        {
+            var instance = SharedDump.Utils.UrlParsing.ExtractMastodonInstance(url) ?? "mastodon.social";
+            return CreateMastodonService(url, instance);
+        }
 
         // If no specific service matches, treat it as a manual input
         return CreateManualService(url);

--- a/feedbackwebapp/Services/Feedback/MastodonFeedbackService.cs
+++ b/feedbackwebapp/Services/Feedback/MastodonFeedbackService.cs
@@ -1,0 +1,59 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using FeedbackWebApp.Services.Authentication;
+using Microsoft.Extensions.Configuration;
+using SharedDump.Models;
+using System.Text.Json;
+
+namespace FeedbackWebApp.Services.Feedback;
+
+public interface IMastodonFeedbackService : IFeedbackService
+{
+    Task<List<CommentThread>> SearchAsync(string query, string instance);
+    Task<CommentThread?> GetThreadAsync(string statusUrl, string instance);
+}
+
+public class MastodonFeedbackService : IMastodonFeedbackService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly IAuthenticationHeaderService _authHeaderService;
+    private readonly string _baseUrl;
+    private readonly string _functionsKey;
+
+    public MastodonFeedbackService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        IAuthenticationHeaderService authHeaderService)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _authHeaderService = authHeaderService;
+        _baseUrl = configuration["FeedbackApi:BaseUrl"] ?? "http://localhost:7071";
+        _functionsKey = configuration["FeedbackApi:FunctionsKey"] ?? string.Empty;
+    }
+
+    public async Task<List<CommentThread>> SearchAsync(string query, string instance)
+    {
+        var url = $"{_baseUrl}/api/mastodon/search?q={Uri.EscapeDataString(query)}&instance={Uri.EscapeDataString(instance)}&code={Uri.EscapeDataString(_functionsKey)}";
+        var client = _httpClientFactory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        await _authHeaderService.AddAuthenticationHeadersAsync(request);
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<List<CommentThread>>(json) ?? new();
+    }
+
+    public async Task<CommentThread?> GetThreadAsync(string statusUrl, string instance)
+    {
+        var url = $"{_baseUrl}/api/mastodon/thread?url={Uri.EscapeDataString(statusUrl)}&instance={Uri.EscapeDataString(instance)}&code={Uri.EscapeDataString(_functionsKey)}";
+        var client = _httpClientFactory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        await _authHeaderService.AddAuthenticationHeadersAsync(request);
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<CommentThread>(json);
+    }
+}

--- a/feedbackwebapp/Services/Mock/MockMastodonFeedbackService.cs
+++ b/feedbackwebapp/Services/Mock/MockMastodonFeedbackService.cs
@@ -1,0 +1,96 @@
+using System.Threading.Tasks;
+using FeedbackWebApp.Services.Authentication;
+using Microsoft.Extensions.Configuration;
+using SharedDump.Models;
+using System.Collections.Generic;
+
+namespace FeedbackWebApp.Services.Mock;
+
+public class MockMastodonFeedbackService : IMastodonFeedbackService
+{
+    public MockMastodonFeedbackService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        IAuthenticationHeaderService authHeaderService)
+    {
+    }
+
+    public Task<List<CommentThread>> SearchAsync(string query, string instance)
+    {
+        return Task.FromResult(new List<CommentThread>
+        {
+            new CommentThread
+            {
+                Id = "mock-123",
+                Platform = "Mastodon",
+                Title = "Mock Mastodon Post",
+                Url = $"https://{instance}/@mockuser/123",
+                Comments = new List<CommentData>
+                {
+                    new CommentData
+                    {
+                        Id = "mock-123",
+                        Author = "MockUser",
+                        Content = "This is a mock Mastodon post.",
+                        CreatedAt = System.DateTime.UtcNow.AddHours(-2),
+                        Metadata = new Dictionary<string, object?>
+                        {
+                            ["username"] = "mockuser",
+                            ["avatar"] = $"https://{instance}/avatars/mock.png"
+                        }
+                    }
+                },
+                Metadata = new Dictionary<string, object?>
+                {
+                    ["instance"] = instance,
+                    ["author"] = "mockuser",
+                    ["created_at"] = System.DateTime.UtcNow.AddHours(-2)
+                }
+            }
+        });
+    }
+
+    public Task<CommentThread?> GetThreadAsync(string statusUrl, string instance)
+    {
+        return Task.FromResult<CommentThread?>(new CommentThread
+        {
+            Id = "mock-123",
+            Platform = "Mastodon",
+            Title = "Mock Mastodon Post",
+            Url = statusUrl,
+            Comments = new List<CommentData>
+            {
+                new CommentData
+                {
+                    Id = "mock-123",
+                    Author = "MockUser",
+                    Content = "This is a mock Mastodon post.",
+                    CreatedAt = System.DateTime.UtcNow.AddHours(-2),
+                    Metadata = new Dictionary<string, object?>
+                    {
+                        ["username"] = "mockuser",
+                        ["avatar"] = $"https://{instance}/avatars/mock.png"
+                    }
+                },
+                new CommentData
+                {
+                    Id = "mock-456",
+                    Author = "ReplyUser",
+                    Content = "This is a mock reply.",
+                    CreatedAt = System.DateTime.UtcNow.AddMinutes(-90),
+                    Metadata = new Dictionary<string, object?>
+                    {
+                        ["username"] = "replyuser",
+                        ["avatar"] = $"https://{instance}/avatars/reply.png"
+                    }
+                }
+            },
+            Metadata = new Dictionary<string, object?>
+            {
+                ["instance"] = instance,
+                ["author"] = "mockuser",
+                ["created_at"] = System.DateTime.UtcNow.AddHours(-2)
+            }
+        });
+    }
+}

--- a/shareddump/Models/Mastodon/ApiModels/MastodonApiModels.cs
+++ b/shareddump/Models/Mastodon/ApiModels/MastodonApiModels.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace SharedDump.Models.Mastodon.ApiModels;
+
+public class MastodonStatus
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("account")]
+    public MastodonAccount Account { get; set; } = new();
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("in_reply_to_id")]
+    public string? InReplyToId { get; set; }
+
+    [JsonPropertyName("replies_count")]
+    public int RepliesCount { get; set; }
+
+    [JsonPropertyName("reblog")]
+    public MastodonStatus? Reblog { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+}
+
+public class MastodonAccount
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("username")]
+    public string Username { get; set; } = string.Empty;
+
+    [JsonPropertyName("display_name")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [JsonPropertyName("avatar")]
+    public string Avatar { get; set; } = string.Empty;
+}
+
+public class MastodonContext
+{
+    [JsonPropertyName("ancestors")]
+    public List<MastodonStatus> Ancestors { get; set; } = new();
+
+    [JsonPropertyName("descendants")]
+    public List<MastodonStatus> Descendants { get; set; } = new();
+}

--- a/shareddump/Models/Mastodon/MastodonFeedbackJsonContext.cs
+++ b/shareddump/Models/Mastodon/MastodonFeedbackJsonContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+using SharedDump.Models.Mastodon.ApiModels;
+
+namespace SharedDump.Models.Mastodon;
+
+[JsonSourceGenerationOptions(WriteIndented = false, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(MastodonStatus))]
+[JsonSerializable(typeof(MastodonAccount))]
+[JsonSerializable(typeof(MastodonContext))]
+public partial class MastodonFeedbackJsonContext : JsonSerializerContext
+{
+}

--- a/shareddump/Services/MastodonServiceAdapter.cs
+++ b/shareddump/Services/MastodonServiceAdapter.cs
@@ -1,0 +1,118 @@
+using SharedDump.Models.Mastodon.ApiModels;
+using SharedDump.Models;
+using SharedDump.Services;
+using Microsoft.Extensions.Logging;
+
+namespace SharedDump.Services;
+
+public interface IMastodonService
+{
+    Task<List<CommentThread>> SearchAsync(string query, string instance, CancellationToken cancellationToken = default);
+    Task<CommentThread?> GetThreadAsync(string statusUrl, string instance, CancellationToken cancellationToken = default);
+}
+
+public class MastodonServiceAdapter : IMastodonService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<MastodonServiceAdapter> _logger;
+
+    public MastodonServiceAdapter(HttpClient httpClient, ILogger<MastodonServiceAdapter> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<List<CommentThread>> SearchAsync(string query, string instance, CancellationToken cancellationToken = default)
+    {
+        // Mastodon does not support global search across all instances.
+        // We'll use the instance's public timeline and filter client-side.
+        var url = $"https://{instance}/api/v2/search?q={Uri.EscapeDataString(query)}&type=statuses&resolve=true&limit=10";
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var statuses = doc.RootElement.GetProperty("statuses");
+        var threads = new List<CommentThread>();
+        foreach (var statusElem in statuses.EnumerateArray())
+        {
+            var status = System.Text.Json.JsonSerializer.Deserialize<MastodonStatus>(statusElem.GetRawText(), MastodonFeedbackJsonContext.Default.MastodonStatus);
+            if (status is not null)
+            {
+                threads.Add(ConvertToCommentThread(status, instance));
+            }
+        }
+        return threads;
+    }
+
+    public async Task<CommentThread?> GetThreadAsync(string statusUrl, string instance, CancellationToken cancellationToken = default)
+    {
+        // Extract status ID from URL
+        var id = ExtractStatusId(statusUrl);
+        if (id is null)
+            return null;
+        var statusApiUrl = $"https://{instance}/api/v1/statuses/{id}";
+        var contextApiUrl = $"https://{instance}/api/v1/statuses/{id}/context";
+        var statusResp = await _httpClient.GetAsync(statusApiUrl, cancellationToken);
+        statusResp.EnsureSuccessStatusCode();
+        var status = await statusResp.Content.ReadFromJsonAsync<MastodonStatus>(MastodonFeedbackJsonContext.Default.MastodonStatus, cancellationToken: cancellationToken);
+        var contextResp = await _httpClient.GetAsync(contextApiUrl, cancellationToken);
+        contextResp.EnsureSuccessStatusCode();
+        var context = await contextResp.Content.ReadFromJsonAsync<MastodonContext>(MastodonFeedbackJsonContext.Default.MastodonContext, cancellationToken: cancellationToken);
+        if (status is null || context is null)
+            return null;
+        var thread = ConvertToCommentThread(status, instance, context);
+        return thread;
+    }
+
+    private static string? ExtractStatusId(string url)
+    {
+        // Example: https://mastodon.social/@user/123456789012345678
+        var parts = url.TrimEnd('/').Split('/');
+        return parts.LastOrDefault();
+    }
+
+    private static CommentThread ConvertToCommentThread(MastodonStatus status, string instance, MastodonContext? context = null)
+    {
+        var thread = new CommentThread
+        {
+            Id = status.Id,
+            Platform = "Mastodon",
+            Title = status.Account.DisplayName ?? status.Account.Username,
+            Url = status.Url ?? $"https://{instance}/@{status.Account.Username}/{status.Id}",
+            Comments = new List<CommentData>(),
+            Metadata = new Dictionary<string, object?>
+            {
+                ["instance"] = instance,
+                ["author"] = status.Account.Username,
+                ["created_at"] = status.CreatedAt,
+            }
+        };
+        // Add root post as first comment
+        thread.Comments.Add(ConvertToCommentData(status));
+        // Add replies if context provided
+        if (context is not null)
+        {
+            foreach (var reply in context.Descendants)
+            {
+                thread.Comments.Add(ConvertToCommentData(reply));
+            }
+        }
+        return thread;
+    }
+
+    private static CommentData ConvertToCommentData(MastodonStatus status)
+    {
+        return new CommentData
+        {
+            Id = status.Id,
+            Author = status.Account.DisplayName ?? status.Account.Username,
+            Content = status.Content,
+            CreatedAt = status.CreatedAt,
+            Metadata = new Dictionary<string, object?>
+            {
+                ["username"] = status.Account.Username,
+                ["avatar"] = status.Account.Avatar,
+            }
+        };
+    }
+}

--- a/shareddump/Services/Mock/MockMastodonService.cs
+++ b/shareddump/Services/Mock/MockMastodonService.cs
@@ -1,0 +1,95 @@
+using SharedDump.Models;
+using Microsoft.Extensions.Logging;
+
+namespace SharedDump.Services.Mock;
+
+public class MockMastodonService : IMastodonService
+{
+    private readonly ILogger<MockMastodonService> _logger;
+
+    public MockMastodonService(ILogger<MockMastodonService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<List<CommentThread>> SearchAsync(string query, string instance, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation($"Mock: Searching Mastodon for '{query}' on instance '{instance}'");
+        return Task.FromResult(new List<CommentThread>
+        {
+            new CommentThread
+            {
+                Id = "123456",
+                Platform = "Mastodon",
+                Title = "Sample Mastodon Post",
+                Url = $"https://{instance}/@sampleuser/123456",
+                Comments = new List<CommentData>
+                {
+                    new CommentData
+                    {
+                        Id = "123456",
+                        Author = "SampleUser",
+                        Content = "This is a sample Mastodon post.",
+                        CreatedAt = DateTime.UtcNow.AddHours(-1),
+                        Metadata = new Dictionary<string, object?>
+                        {
+                            ["username"] = "sampleuser",
+                            ["avatar"] = "https://{instance}/avatars/sample.png"
+                        }
+                    }
+                },
+                Metadata = new Dictionary<string, object?>
+                {
+                    ["instance"] = instance,
+                    ["author"] = "sampleuser",
+                    ["created_at"] = DateTime.UtcNow.AddHours(-1)
+                }
+            }
+        });
+    }
+
+    public Task<CommentThread?> GetThreadAsync(string statusUrl, string instance, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation($"Mock: Getting Mastodon thread for '{statusUrl}' on instance '{instance}'");
+        return Task.FromResult<CommentThread?>(new CommentThread
+        {
+            Id = "123456",
+            Platform = "Mastodon",
+            Title = "Sample Mastodon Post",
+            Url = statusUrl,
+            Comments = new List<CommentData>
+            {
+                new CommentData
+                {
+                    Id = "123456",
+                    Author = "SampleUser",
+                    Content = "This is a sample Mastodon post.",
+                    CreatedAt = DateTime.UtcNow.AddHours(-1),
+                    Metadata = new Dictionary<string, object?>
+                    {
+                        ["username"] = "sampleuser",
+                        ["avatar"] = "https://{instance}/avatars/sample.png"
+                    }
+                },
+                new CommentData
+                {
+                    Id = "654321",
+                    Author = "ReplyUser",
+                    Content = "This is a reply to the sample post.",
+                    CreatedAt = DateTime.UtcNow.AddMinutes(-30),
+                    Metadata = new Dictionary<string, object?>
+                    {
+                        ["username"] = "replyuser",
+                        ["avatar"] = "https://{instance}/avatars/reply.png"
+                    }
+                }
+            },
+            Metadata = new Dictionary<string, object?>
+            {
+                ["instance"] = instance,
+                ["author"] = "sampleuser",
+                ["created_at"] = DateTime.UtcNow.AddHours(-1)
+            }
+        });
+    }
+}

--- a/shareddump/Utils/UrlParsing.cs
+++ b/shareddump/Utils/UrlParsing.cs
@@ -1,3 +1,36 @@
+    public static bool IsMastodonUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return false;
+        // Heuristic: must contain /@username/ and end with a numeric ID
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length >= 2 && segments[0].StartsWith("@") && long.TryParse(segments[^1], out _))
+            return true;
+        return false;
+    }
+
+    public static string? ExtractMastodonInstance(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return null;
+        return uri.Host;
+    }
+
+    public static string? ExtractMastodonStatusId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return null;
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length >= 2 && long.TryParse(segments[^1], out var id))
+            return segments[^1];
+        return null;
+    }
 namespace SharedDump.Utils;
 
 public static class UrlParsing


### PR DESCRIPTION
Introduce a new Mastodon service that allows searching and retrieving threads from Mastodon instances. This integration includes necessary models, service interfaces, and Azure Functions for handling requests.