### PR TITLE
[shareddump/feedbackfunctions] YouTube API performance improvements

### DIFF
--- a/feedbackflow.tests/TableInitializationServiceTests.cs
+++ b/feedbackflow.tests/TableInitializationServiceTests.cs
@@ -212,7 +212,8 @@ public class TableInitializationServiceTests
         BlobContainerClient? reportsContainer = null,
         BlobContainerClient? reportsSummaryContainer = null,
         BlobContainerClient? weeklySummariesContainer = null,
-        BlobContainerClient? sharedAnalysesContainer = null)
+        BlobContainerClient? sharedAnalysesContainer = null,
+        BlobContainerClient? youtubeCacheContainer = null)
     {
         return new FeedbackStorageClients(
             blobServiceClient: null,
@@ -221,6 +222,7 @@ public class TableInitializationServiceTests
             reportsSummaryContainer: reportsSummaryContainer ?? Substitute.For<BlobContainerClient>(),
             weeklySummariesContainer: weeklySummariesContainer ?? Substitute.For<BlobContainerClient>(),
             sharedAnalysesContainer: sharedAnalysesContainer ?? Substitute.For<BlobContainerClient>(),
+            youtubeCacheContainer: youtubeCacheContainer ?? Substitute.For<BlobContainerClient>(),
             userAccountsTable: userAccountsTable ?? Substitute.For<TableClient>(),
             usageRecordsTable: usageRecordsTable ?? Substitute.For<TableClient>(),
             apiKeysTable: apiKeysTable ?? Substitute.For<TableClient>(),

--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -24,6 +25,7 @@ using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
 using FeedbackFunctions.Services.Account;
+using FeedbackFunctions.Services.Storage;
 using FeedbackFunctions.Services.Twitter;
 using FeedbackFunctions.Utils;
 using SharedDump.Models.Account;
@@ -52,6 +54,8 @@ public class FeedbackFunctions
     private readonly IUserAccountService _userAccountService;
     private readonly ITwitterThreadCacheService _twitterThreadCacheService;
     private readonly IFeatureGateService _featureGateService;
+    private readonly BlobContainerClient _youtubeCacheContainer;
+    private static readonly TimeSpan _youtubeVideoCacheTtl = TimeSpan.FromHours(1);
 
     /// <summary>
     /// Initializes a new instance of the FeedbackFunctions class
@@ -78,7 +82,8 @@ public class FeedbackFunctions
         AuthenticationMiddleware authMiddleware,
         IUserAccountService userAccountService,
         ITwitterThreadCacheService twitterThreadCacheService,
-        IFeatureGateService featureGateService)
+        IFeatureGateService featureGateService,
+        FeedbackStorageClients storageClients)
     {
         _logger = logger;
         _githubService = githubService;
@@ -93,6 +98,7 @@ public class FeedbackFunctions
         _userAccountService = userAccountService;
         _twitterThreadCacheService = twitterThreadCacheService;
         _featureGateService = featureGateService;
+        _youtubeCacheContainer = storageClients.YouTubeCacheContainer;
     }
 
     /// <summary>
@@ -370,13 +376,40 @@ public class FeedbackFunctions
                 }
             }
 
+            // Check blob cache for each video — only fetch uncached ones from the API
+            await _youtubeCacheContainer.CreateIfNotExistsAsync();
             var outputVideos = new List<YouTubeOutputVideo>();
+            var uncachedIds = new List<string>();
 
             foreach (var videoId in allVideoIds)
             {
-                var video = await _ytService.ProcessVideo(videoId);
-                outputVideos.Add(video);
+                var cached = await TryGetCachedVideoAsync(videoId);
+                if (cached is not null)
+                {
+                    _logger.LogInformation("YouTube cache hit for video {VideoId}", videoId);
+                    outputVideos.Add(cached);
+                }
+                else
+                {
+                    uncachedIds.Add(videoId);
+                }
             }
+
+            if (uncachedIds.Count > 0)
+            {
+                var freshVideos = await _ytService.ProcessVideosBatch(uncachedIds);
+                foreach (var video in freshVideos)
+                {
+                    await SetCachedVideoAsync(video);
+                }
+                outputVideos.AddRange(freshVideos);
+            }
+
+            // Preserve original order
+            outputVideos = [.. allVideoIds
+                .Select(id => outputVideos.FirstOrDefault(v => v.Id == id))
+                .Where(v => v is not null)
+                .Select(v => v!)];
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             await response.WriteAsJsonAsync(outputVideos);
@@ -1231,6 +1264,49 @@ public class FeedbackFunctions
             {
                 AppendCommentsToText(result, comment.Replies, depth + 1);
             }
+        }
+    }
+
+    #endregion
+
+    #region YouTube Cache Helpers
+
+    private sealed record YouTubeCacheEntry(YouTubeOutputVideo Video, DateTimeOffset CachedAt);
+
+    private async Task<YouTubeOutputVideo?> TryGetCachedVideoAsync(string videoId)
+    {
+        try
+        {
+            var blobClient = _youtubeCacheContainer.GetBlobClient($"{videoId}.json");
+            if (!await blobClient.ExistsAsync())
+                return null;
+
+            var download = await blobClient.DownloadContentAsync();
+            var entry = JsonSerializer.Deserialize<YouTubeCacheEntry>(download.Value.Content.ToStream());
+            if (entry is null || DateTimeOffset.UtcNow - entry.CachedAt > _youtubeVideoCacheTtl)
+                return null;
+
+            return entry.Video;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read YouTube cache for video {VideoId}", videoId);
+            return null;
+        }
+    }
+
+    private async Task SetCachedVideoAsync(YouTubeOutputVideo video)
+    {
+        try
+        {
+            var entry = new YouTubeCacheEntry(video, DateTimeOffset.UtcNow);
+            var json = JsonSerializer.SerializeToUtf8Bytes(entry);
+            var blobClient = _youtubeCacheContainer.GetBlobClient($"{video.Id}.json");
+            await blobClient.UploadAsync(new BinaryData(json), overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write YouTube cache for video {VideoId}", video.Id);
         }
     }
 

--- a/feedbackfunctions/Feeds/ContentFeedFunctions.cs
+++ b/feedbackfunctions/Feeds/ContentFeedFunctions.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text.Json;
+using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -12,6 +14,7 @@ using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
 using FeedbackFunctions.Services.Account;
+using FeedbackFunctions.Services.Storage;
 using SharedDump.Models.Account;
 
 namespace FeedbackFunctions;
@@ -32,7 +35,9 @@ public class ContentFeedFunctions
     private readonly IRedditService _redditService;
     private readonly AuthenticationMiddleware _authMiddleware;
     private readonly IUserAccountService _userAccountService;
+    private readonly BlobContainerClient _youtubeCacheContainer;
     private static readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan _youtubeSearchCacheTtl = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// Initializes a new instance of the ContentFeedFunctions class
@@ -41,14 +46,14 @@ public class ContentFeedFunctions
     /// <param name="hackerNewsService">HackerNews service for story operations</param>
     /// <param name="youtubeService">YouTube service for video operations</param>
     /// <param name="redditService">Reddit service for thread operations</param>
-    /// <param name="authMiddleware">Authentication middleware for request validation</param>
     public ContentFeedFunctions(
         ILogger<ContentFeedFunctions> logger,
         IHackerNewsService hackerNewsService,
         IYouTubeService youtubeService,
         IRedditService redditService,
         AuthenticationMiddleware authMiddleware,
-        IUserAccountService userAccountService)
+        IUserAccountService userAccountService,
+        FeedbackStorageClients storageClients)
     {
         _logger = logger;
         _hnService = hackerNewsService;
@@ -56,6 +61,7 @@ public class ContentFeedFunctions
         _redditService = redditService;
         _authMiddleware = authMiddleware;
         _userAccountService = userAccountService;
+        _youtubeCacheContainer = storageClients.YouTubeCacheContainer;
     }
 
     /// <summary>
@@ -112,7 +118,24 @@ public class ContentFeedFunctions
             }
 
             var cutoffDate = DateTimeOffset.UtcNow.AddDays(-days);
-            var videos = await _ytService.SearchVideosBasicInfo(topic ?? "", tag ?? "", cutoffDate); // Changed method name
+
+            // Check blob cache for this search query before hitting the YouTube API
+            await _youtubeCacheContainer.CreateIfNotExistsAsync();
+            var cacheKey = $"search-{SanitizeCacheKey(topic ?? "")}-{SanitizeCacheKey(tag ?? "")}-{days}d.json";
+            var cachedVideos = await TryGetCachedSearchResultAsync(cacheKey);
+            if (cachedVideos is not null)
+            {
+                _logger.LogInformation("YouTube search cache hit for key {CacheKey}", cacheKey);
+                var cachedResponse = req.CreateResponse(HttpStatusCode.OK);
+                await cachedResponse.WriteAsJsonAsync(cachedVideos);
+                await user!.TrackUsageAsync(UsageType.FeedQuery, _userAccountService, _logger, $"Topic: {topic ?? tag}, Videos: {cachedVideos.Count} (cached)");
+                return cachedResponse;
+            }
+
+            var videos = await _ytService.SearchVideosBasicInfo(topic ?? "", tag ?? "", cutoffDate);
+
+            // Store fresh results in cache for next request
+            await SetCachedSearchResultAsync(cacheKey, videos);
             
             var response = req.CreateResponse(HttpStatusCode.OK);
             await response.WriteAsJsonAsync(videos);
@@ -264,4 +287,46 @@ public class ContentFeedFunctions
             return string.Empty;
         }
     }
+
+    private sealed record YouTubeSearchCacheEntry(List<YouTubeOutputVideo> Videos, DateTimeOffset CachedAt);
+
+    private async Task<List<YouTubeOutputVideo>?> TryGetCachedSearchResultAsync(string cacheKey)
+    {
+        try
+        {
+            var blobClient = _youtubeCacheContainer.GetBlobClient(cacheKey);
+            if (!await blobClient.ExistsAsync())
+                return null;
+
+            var download = await blobClient.DownloadContentAsync();
+            var entry = JsonSerializer.Deserialize<YouTubeSearchCacheEntry>(download.Value.Content.ToStream());
+            if (entry is null || DateTimeOffset.UtcNow - entry.CachedAt > _youtubeSearchCacheTtl)
+                return null;
+
+            return entry.Videos;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read YouTube search cache for key {CacheKey}", cacheKey);
+            return null;
+        }
+    }
+
+    private async Task SetCachedSearchResultAsync(string cacheKey, List<YouTubeOutputVideo> videos)
+    {
+        try
+        {
+            var entry = new YouTubeSearchCacheEntry(videos, DateTimeOffset.UtcNow);
+            var json = JsonSerializer.SerializeToUtf8Bytes(entry);
+            var blobClient = _youtubeCacheContainer.GetBlobClient(cacheKey);
+            await blobClient.UploadAsync(new BinaryData(json), overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write YouTube search cache for key {CacheKey}", cacheKey);
+        }
+    }
+
+    private static string SanitizeCacheKey(string value) =>
+        string.Concat(value.ToLowerInvariant().Where(c => char.IsLetterOrDigit(c) || c == '-').Take(50));
 }

--- a/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
+++ b/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
@@ -15,6 +15,7 @@ public class FeedbackStorageClients
             blobServiceClient.GetBlobContainerClient(StorageNames.ReportsSummaryContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.WeeklySummariesContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.SharedAnalysesContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.YouTubeCacheContainer),
             tableServiceClient.GetTableClient(StorageNames.UserAccountsTable),
             tableServiceClient.GetTableClient(StorageNames.UsageRecordsTable),
             tableServiceClient.GetTableClient(StorageNames.ApiKeysTable),
@@ -33,6 +34,7 @@ public class FeedbackStorageClients
         BlobContainerClient reportsSummaryContainer,
         BlobContainerClient weeklySummariesContainer,
         BlobContainerClient sharedAnalysesContainer,
+        BlobContainerClient youtubeCacheContainer,
         TableClient userAccountsTable,
         TableClient usageRecordsTable,
         TableClient apiKeysTable,
@@ -48,6 +50,7 @@ public class FeedbackStorageClients
         ReportsSummaryContainer = reportsSummaryContainer;
         WeeklySummariesContainer = weeklySummariesContainer;
         SharedAnalysesContainer = sharedAnalysesContainer;
+        YouTubeCacheContainer = youtubeCacheContainer;
         UserAccountsTable = userAccountsTable;
         UsageRecordsTable = usageRecordsTable;
         ApiKeysTable = apiKeysTable;
@@ -69,6 +72,8 @@ public class FeedbackStorageClients
     public BlobContainerClient WeeklySummariesContainer { get; }
 
     public BlobContainerClient SharedAnalysesContainer { get; }
+
+    public BlobContainerClient YouTubeCacheContainer { get; }
 
     public TableClient UserAccountsTable { get; }
 

--- a/feedbackfunctions/Services/Storage/StorageNames.cs
+++ b/feedbackfunctions/Services/Storage/StorageNames.cs
@@ -6,6 +6,7 @@ public static class StorageNames
     public const string ReportsSummaryContainer = "reports-summary";
     public const string WeeklySummariesContainer = "weekly-summaries";
     public const string SharedAnalysesContainer = "shared-analyses";
+    public const string YouTubeCacheContainer = "youtube-cache";
 
     public const string UserAccountsTable = "UserAccounts";
     public const string UsageRecordsTable = "UsageRecords";

--- a/feedbackwebapp/Services/Feedback/YouTubeFeedbackService.cs
+++ b/feedbackwebapp/Services/Feedback/YouTubeFeedbackService.cs
@@ -111,7 +111,6 @@ public class YouTubeFeedbackService : FeedbackService, IYouTubeFeedbackService
             var videoComments = $"Video: {video.Title}\n\n" + string.Join("\n\n", video.Comments.Select(c => $"Comment by {c.Author}: {c.Text}"));
 
             UpdateStatus(FeedbackProcessStatus.AnalyzingComments, $"Analyzing {video.Comments.Count} comments for video: {video.Title}...");
-            await Task.Delay(1500); // Simulate some processing delay
             try
             {
                 var videoMarkdown = await AnalyzeCommentsInternal($"YouTube", videoComments, video.Comments.Count);

--- a/shareddump/Json/YouTubeJsonContext.cs
+++ b/shareddump/Json/YouTubeJsonContext.cs
@@ -20,4 +20,6 @@ namespace SharedDump.Json;
 [JsonSerializable(typeof(YouTubeCommentDetails))]
 [JsonSerializable(typeof(YouTubeSearchResponse))]
 [JsonSerializable(typeof(YouTubeVideoStatisticsResponse))]
+[JsonSerializable(typeof(YouTubeVideoResponseWithId))]
+[JsonSerializable(typeof(YouTubeVideoItemWithId))]
 public partial class YouTubeJsonContext : JsonSerializerContext { }

--- a/shareddump/Models/YouTube/YouTubeApiModels.cs
+++ b/shareddump/Models/YouTube/YouTubeApiModels.cs
@@ -58,6 +58,18 @@ public class YouTubeVideoResponse
     public required List<YouTubeVideoItem> Items { get; set; }
 }
 
+public class YouTubeVideoItemWithId
+{
+    public required string Id { get; set; }
+    public required YouTubeVideoSnippet Snippet { get; set; }
+}
+
+public class YouTubeVideoResponseWithId
+{
+    public string? NextPageToken { get; set; }
+    public required List<YouTubeVideoItemWithId> Items { get; set; }
+}
+
 public class YouTubeVideoItem
 {
     public required YouTubeVideoSnippet Snippet { get; set; }

--- a/shareddump/Models/YouTube/YouTubeService.cs
+++ b/shareddump/Models/YouTube/YouTubeService.cs
@@ -103,81 +103,116 @@ public class YouTubeService : IYouTubeService
 
     public async Task<YouTubeOutputVideo> ProcessVideo(string videoId)
     {
-        var video = new YouTubeOutputVideo
-        {
-            Id = videoId,
-            Url = $"https://www.youtube.com/watch?v={videoId}"
-        };
+        var results = await ProcessVideosBatch([videoId]);
+        return results.Count > 0 ? results[0] : new YouTubeOutputVideo { Id = videoId, Url = $"https://www.youtube.com/watch?v={videoId}" };
+    }
 
-        try
-        {
-            var videoUrl = $"https://youtube.googleapis.com/youtube/v3/videos?part=snippet&id={videoId}&key={_apiKey}";
-            var videoResponse = await _client.GetFromJsonAsync<YouTubeVideoResponse>(videoUrl, YouTubeJsonContext.Default.YouTubeVideoResponse);
+    public async Task<List<YouTubeOutputVideo>> ProcessVideosBatch(IEnumerable<string> videoIds)
+    {
+        var idList = videoIds.ToList();
+        if (idList.Count == 0)
+            return [];
 
-            if (videoResponse?.Items.Count > 0)
+        // Batch-fetch all video metadata — YouTube supports up to 50 IDs per request (1 quota unit vs N units)
+        var titleLookup = new Dictionary<string, (string title, DateTime uploadDate)>();
+        foreach (var chunk in idList.Chunk(50))
+        {
+            var ids = string.Join(",", chunk);
+            var videoUrl = $"https://youtube.googleapis.com/youtube/v3/videos?part=snippet&id={ids}&key={_apiKey}";
+            try
             {
-                var videoInfo = videoResponse.Items[0];
-                video.Title = videoInfo.Snippet.Title;
-                video.UploadDate = videoInfo.Snippet.PublishedAt;
+                var videoResponse = await _client.GetFromJsonAsync<YouTubeVideoResponseWithId>(videoUrl, YouTubeJsonContext.Default.YouTubeVideoResponseWithId);
+                if (videoResponse?.Items is not null)
+                {
+                    foreach (var item in videoResponse.Items)
+                        titleLookup[item.Id] = (item.Snippet.Title, item.Snippet.PublishedAt);
+                }
             }
-
-            var commentsList = new List<YouTubeOutputComment>();
-            string? nextPageToken = null;
-
-            do
+            catch (Exception ex)
             {
-                var commentsUrl = $"https://youtube.googleapis.com/youtube/v3/commentThreads?part=snippet,replies&maxResults=100&videoId={videoId}&key={_apiKey}";
-                if (nextPageToken is not null)
+                Console.WriteLine($"An error occurred fetching video metadata batch: {ex.Message}");
+            }
+        }
+
+        // Fetch comments for all videos in parallel, capped at 3 concurrent to respect rate limits
+        var semaphore = new SemaphoreSlim(3, 3);
+        var tasks = idList.Select(async videoId =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                var video = new YouTubeOutputVideo
                 {
-                    commentsUrl += $"&pageToken={nextPageToken}";
+                    Id = videoId,
+                    Url = $"https://www.youtube.com/watch?v={videoId}"
+                };
+
+                if (titleLookup.TryGetValue(videoId, out var meta))
+                {
+                    video.Title = meta.title;
+                    video.UploadDate = meta.uploadDate;
                 }
 
-                var commentResponse = await _client.GetFromJsonAsync<YouTubeCommentResponse>(commentsUrl, YouTubeJsonContext.Default.YouTubeCommentResponse);
+                var commentsList = new List<YouTubeOutputComment>();
+                string? nextPageToken = null;
 
-                if (commentResponse?.Items is null)
+                do
                 {
-                    break;
-                }
+                    var commentsUrl = $"https://youtube.googleapis.com/youtube/v3/commentThreads?part=snippet,replies&maxResults=100&videoId={videoId}&key={_apiKey}";
+                    if (nextPageToken is not null)
+                        commentsUrl += $"&pageToken={nextPageToken}";
 
-                foreach (var item in commentResponse.Items)
-                {
-                    var comment = item.Snippet.TopLevelComment;
-                    commentsList.Add(new YouTubeOutputComment
+                    try
                     {
-                        Id = comment.Id,
-                        Author = comment.Snippet.AuthorDisplayName,
-                        Text = comment.Snippet.TextDisplay,
-                        PublishedAt = comment.Snippet.PublishedAt
-                    });
+                        var commentResponse = await _client.GetFromJsonAsync<YouTubeCommentResponse>(commentsUrl, YouTubeJsonContext.Default.YouTubeCommentResponse);
 
-                    if (item.Replies.Comments.Count > 0)
-                    {
-                        foreach (var reply in item.Replies.Comments)
+                        if (commentResponse?.Items is null)
+                            break;
+
+                        foreach (var item in commentResponse.Items)
                         {
+                            var comment = item.Snippet.TopLevelComment;
                             commentsList.Add(new YouTubeOutputComment
                             {
-                                Id = reply.Id,
-                                Author = reply.Snippet.AuthorDisplayName,
-                                Text = reply.Snippet.TextDisplay,
-                                PublishedAt = reply.Snippet.PublishedAt,
-                                ParentId = item.Id
+                                Id = comment.Id,
+                                Author = comment.Snippet.AuthorDisplayName,
+                                Text = comment.Snippet.TextDisplay,
+                                PublishedAt = comment.Snippet.PublishedAt
                             });
+
+                            foreach (var reply in item.Replies.Comments)
+                            {
+                                commentsList.Add(new YouTubeOutputComment
+                                {
+                                    Id = reply.Id,
+                                    Author = reply.Snippet.AuthorDisplayName,
+                                    Text = reply.Snippet.TextDisplay,
+                                    PublishedAt = reply.Snippet.PublishedAt,
+                                    ParentId = item.Id
+                                });
+                            }
                         }
+
+                        nextPageToken = commentResponse.NextPageToken;
                     }
-                }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"An error occurred fetching comments for {videoId}: {ex.Message}");
+                        break;
+                    }
+                } while (!string.IsNullOrEmpty(nextPageToken));
 
-                nextPageToken = commentResponse.NextPageToken;
+                video.Comments = commentsList;
+                return video;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
 
-            } while (!string.IsNullOrEmpty(nextPageToken));
-
-            video.Comments = commentsList;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"An error occurred: {ex.Message}");
-        }
-
-        return video;
+        var results = await Task.WhenAll(tasks);
+        return [.. results];
     }
 
     public async Task<List<YouTubeOutputVideo>> SearchVideos(string topic, string tag, DateTimeOffset cutoffDate)
@@ -239,13 +274,7 @@ public class YouTubeService : IYouTubeService
             }
         } while (!string.IsNullOrEmpty(pageToken));
 
-        var videos = new List<YouTubeOutputVideo>();
-        foreach (var videoId in videoIds)
-        {
-            var video = await ProcessVideo(videoId);
-            videos.Add(video);
-        }
-
+        var videos = await ProcessVideosBatch(videoIds);
         return videos;
     }
 

--- a/shareddump/Services/Interfaces/IYouTubeService.cs
+++ b/shareddump/Services/Interfaces/IYouTubeService.cs
@@ -7,6 +7,7 @@ public interface IYouTubeService
     Task<IEnumerable<string>> GetPlaylistVideos(string playlistId);
     Task<IEnumerable<string>> GetChannelVideos(string channelId);
     Task<YouTubeOutputVideo> ProcessVideo(string videoId);
+    Task<List<YouTubeOutputVideo>> ProcessVideosBatch(IEnumerable<string> videoIds);
     Task<List<YouTubeOutputVideo>> SearchVideos(string topic, string tag, DateTimeOffset cutoffDate);
     Task<List<YouTubeOutputVideo>> SearchVideosBasicInfo(string searchQuery, string tag, DateTimeOffset publishedAfter);
 }

--- a/shareddump/Services/Mock/MockYouTubeService.cs
+++ b/shareddump/Services/Mock/MockYouTubeService.cs
@@ -42,27 +42,35 @@ public class MockYouTubeService : IYouTubeService
 
     public async Task<YouTubeOutputVideo> ProcessVideo(string videoId)
     {
-        // Simulate processing delay
-        await Task.Delay(800);
+        var results = await ProcessVideosBatch([videoId]);
+        return results.Count > 0 ? results[0] : new YouTubeOutputVideo { Id = videoId, Url = $"https://www.youtube.com/watch?v={videoId}" };
+    }
 
-        // Generate mock video data based on the video ID
-        var baseDate = DateTime.UtcNow.AddDays(-Random.Shared.Next(1, 30));
-        
-        return new YouTubeOutputVideo
+    public async Task<List<YouTubeOutputVideo>> ProcessVideosBatch(IEnumerable<string> videoIds)
+    {
+        await Task.Delay(300); // Simulate batch network delay
+
+        var results = new List<YouTubeOutputVideo>();
+        foreach (var videoId in videoIds)
         {
-            Id = videoId,
-            Title = $"Mock Video: {GetMockTitle(videoId)}",
-            Url = $"https://www.youtube.com/watch?v={videoId}",
-            UploadDate = baseDate,
-            PublishedAt = baseDate,
-            ChannelId = "mockChannelId123",
-            ChannelTitle = "Mock Developer Channel",
-            Description = GetMockDescription(videoId),
-            ViewCount = Random.Shared.Next(1000, 100000),
-            LikeCount = Random.Shared.Next(50, 5000),
-            CommentCount = Random.Shared.Next(10, 500),
-            Comments = GenerateMockComments(videoId, baseDate)
-        };
+            var baseDate = DateTime.UtcNow.AddDays(-Random.Shared.Next(1, 30));
+            results.Add(new YouTubeOutputVideo
+            {
+                Id = videoId,
+                Title = $"Mock Video: {GetMockTitle(videoId)}",
+                Url = $"https://www.youtube.com/watch?v={videoId}",
+                UploadDate = baseDate,
+                PublishedAt = baseDate,
+                ChannelId = "mockChannelId123",
+                ChannelTitle = "Mock Developer Channel",
+                Description = GetMockDescription(videoId),
+                ViewCount = Random.Shared.Next(1000, 100000),
+                LikeCount = Random.Shared.Next(50, 5000),
+                CommentCount = Random.Shared.Next(10, 500),
+                Comments = GenerateMockComments(videoId, baseDate)
+            });
+        }
+        return results;
     }
 
     public async Task<List<YouTubeOutputVideo>> SearchVideos(string topic, string tag, DateTimeOffset cutoffDate)


### PR DESCRIPTION
## Summary

Three targeted performance improvements to the YouTube API integration, plus a bonus bug fix.

---

### 1. Parallelize `ProcessVideo` calls with `SemaphoreSlim(3)`

**Before:** Videos were processed one-at-a-time in a `foreach` loop. Each call made 2+ serial HTTP round-trips to YouTube. A 10-video playlist = ~20+ serial HTTP calls.

**After:** New `ProcessVideosBatch(IEnumerable<string> videoIds)` method uses `Task.WhenAll` capped at 3 concurrent requests via `SemaphoreSlim` — reducing wall-clock time from O(N) to ~O(N/3). Both `GetYouTubeFeedback` and `SearchVideos` now use this.

---

### 2. Batch video metadata into a single API call

**Before:** `ProcessVideo` made a separate `videos?part=snippet&id={singleId}` call per video — N calls for N videos.

**After:** `ProcessVideosBatch` batches all video IDs (up to 50 per request, per YouTube's API limit) into a single `videos?part=snippet` call using the new `YouTubeVideoResponseWithId`/`YouTubeVideoItemWithId` models. Saves both latency and precious YouTube quota units (10,000/day limit).

---

### 3. Add blob caching for YouTube results

**Before:** `GetYouTubeFeedback` and `GetRecentYouTubeVideos` had no caching — every request hit the YouTube API live. (HackerNews already had blob caching; YouTube didn't.)

**After:**
- `GetYouTubeFeedback`: Per-video cache with **1-hour TTL**, stored in a new `youtube-cache` blob container. Only uncached video IDs hit the API.
- `GetRecentYouTubeVideos`: Per-search-query cache with **30-minute TTL**, keyed by `search-{topic}-{tag}-{days}d.json`.

---

### Bonus: Remove artificial `Task.Delay(1500)` bug fix

`YouTubeFeedbackService.cs` had a hardcoded `await Task.Delay(1500)` inside the per-video playlist analysis loop — adding 1.5 × N seconds of dead wait for no reason. Removed.

---

## Files Changed

| File | Change |
|------|--------|
| `shareddump/Services/Interfaces/IYouTubeService.cs` | Add `ProcessVideosBatch` to interface |
| `shareddump/Models/YouTube/YouTubeService.cs` | Implement `ProcessVideosBatch` with batching + parallelism |
| `shareddump/Models/YouTube/YouTubeApiModels.cs` | Add `YouTubeVideoResponseWithId` / `YouTubeVideoItemWithId` |
| `shareddump/Json/YouTubeJsonContext.cs` | Register new API models in JSON context |
| `shareddump/Services/Mock/MockYouTubeService.cs` | Implement `ProcessVideosBatch` in mock |
| `feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs` | Use `ProcessVideosBatch`, add per-video blob cache |
| `feedbackfunctions/Feeds/ContentFeedFunctions.cs` | Add per-search-query blob cache to `GetRecentYouTubeVideos` |
| `feedbackfunctions/Services/Storage/StorageNames.cs` | Add `YouTubeCacheContainer` constant |
| `feedbackfunctions/Services/Storage/FeedbackStorageClients.cs` | Add `YouTubeCacheContainer` property |
| `feedbackwebapp/Services/Feedback/YouTubeFeedbackService.cs` | Remove `Task.Delay(1500)` |
| `feedbackflow.tests/TableInitializationServiceTests.cs` | Update test helper for new constructor parameter |
