### PR TITLE
[feedbackfunctions] Persist Reddit report raw data + admin download portal

### DIFF
--- a/feedbackflow.tests/TableInitializationServiceTests.cs
+++ b/feedbackflow.tests/TableInitializationServiceTests.cs
@@ -212,7 +212,8 @@ public class TableInitializationServiceTests
         BlobContainerClient? reportsContainer = null,
         BlobContainerClient? reportsSummaryContainer = null,
         BlobContainerClient? weeklySummariesContainer = null,
-        BlobContainerClient? sharedAnalysesContainer = null)
+        BlobContainerClient? sharedAnalysesContainer = null,
+        BlobContainerClient? redditReportDataContainer = null)
     {
         return new FeedbackStorageClients(
             blobServiceClient: null,
@@ -221,6 +222,7 @@ public class TableInitializationServiceTests
             reportsSummaryContainer: reportsSummaryContainer ?? Substitute.For<BlobContainerClient>(),
             weeklySummariesContainer: weeklySummariesContainer ?? Substitute.For<BlobContainerClient>(),
             sharedAnalysesContainer: sharedAnalysesContainer ?? Substitute.For<BlobContainerClient>(),
+            redditReportDataContainer: redditReportDataContainer ?? Substitute.For<BlobContainerClient>(),
             userAccountsTable: userAccountsTable ?? Substitute.For<TableClient>(),
             usageRecordsTable: usageRecordsTable ?? Substitute.For<TableClient>(),
             apiKeysTable: apiKeysTable ?? Substitute.For<TableClient>(),

--- a/feedbackfunctions/FeedbackJsonContext.cs
+++ b/feedbackfunctions/FeedbackJsonContext.cs
@@ -4,6 +4,7 @@ using SharedDump.Models.HackerNews;
 using SharedDump.Models.YouTube;
 using SharedDump.Models.Reddit;
 using SharedDump.Models.ContentSearch;
+using SharedDump.Models.Reports;
 
 namespace FeedbackFunctions;
 
@@ -14,6 +15,7 @@ namespace FeedbackFunctions;
 [JsonSerializable(typeof(HackerNewsItem[]))]
 [JsonSerializable(typeof(YouTubeOutputVideo[]))]
 [JsonSerializable(typeof(RedditThreadModel[]))]
+[JsonSerializable(typeof(RedditReportRawData))]
 [JsonSerializable(typeof(AnalyzeCommentsRequest))]
 [JsonSerializable(typeof(SaveAnalysisRequest))]
 [JsonSerializable(typeof(UpdateVisibilityRequest))]

--- a/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
+++ b/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using FeedbackFunctions.Attributes;
+using FeedbackFunctions.Middleware;
+using FeedbackFunctions.Services.Account;
+using FeedbackFunctions.Services.Reports;
+using SharedDump.Models.Account;
+using SharedDump.Models.Reports;
+
+namespace FeedbackFunctions.Reports;
+
+/// <summary>
+/// Admin-only Azure Functions for listing generated reports and downloading their raw data.
+/// </summary>
+public class ReportDataAdminFunctions
+{
+    private readonly ILogger<ReportDataAdminFunctions> _logger;
+    private readonly AuthenticationMiddleware _authMiddleware;
+    private readonly IUserAccountService _userAccountService;
+    private readonly IReportCacheService _cacheService;
+    private readonly IReportStorageService _reportStorage;
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public ReportDataAdminFunctions(
+        ILogger<ReportDataAdminFunctions> logger,
+        AuthenticationMiddleware authMiddleware,
+        IUserAccountService userAccountService,
+        IReportCacheService cacheService,
+        IReportStorageService reportStorage)
+    {
+        _logger = logger;
+        _authMiddleware = authMiddleware;
+        _userAccountService = userAccountService;
+        _cacheService = cacheService;
+        _reportStorage = reportStorage;
+    }
+
+    /// <summary>
+    /// Lists all generated Reddit reports (metadata only) for the admin report-data portal.
+    /// Indicates whether raw downloadable data is available for each report.
+    /// </summary>
+    [Function("GetAllReports")]
+    [Authorize]
+    public async Task<HttpResponseData> GetAllReports(
+        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            _logger.LogInformation("GetAllReports invoked");
+
+            var reports = await _cacheService.GetReportsAsync("reddit", null);
+            await _reportStorage.EnsureInitializedAsync();
+
+            // Determine which reports have raw data available
+            var rawDataIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await foreach (var blob in _reportStorage.RedditReportDataContainer.GetBlobsAsync())
+            {
+                rawDataIds.Add(Path.GetFileNameWithoutExtension(blob.Name));
+            }
+
+            var items = reports
+                .OrderByDescending(r => r.GeneratedAt)
+                .Select(r => new ReportDataListItem
+                {
+                    Id = r.Id,
+                    Source = r.Source,
+                    SubSource = r.SubSource,
+                    GeneratedAt = r.GeneratedAt,
+                    CutoffDate = r.CutoffDate,
+                    ThreadCount = r.ThreadCount,
+                    CommentCount = r.CommentCount,
+                    HasRawData = rawDataIds.Contains(r.Id.ToString())
+                })
+                .ToList();
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(new ReportDataListResponse { Reports = items });
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in GetAllReports endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to retrieve reports. Please try again later.");
+            return error;
+        }
+    }
+
+    /// <summary>
+    /// Downloads the raw fetched data (threads + comments + subreddit info) for a report as JSON.
+    /// </summary>
+    [Function("DownloadReportRawData")]
+    [Authorize]
+    public async Task<HttpResponseData> DownloadReportRawData(
+        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            var query = QueryHelpers.ParseQuery(req.Url.Query);
+            if (!query.TryGetValue("id", out var idValues))
+            {
+                var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+                await bad.WriteStringAsync("Missing required query parameter 'id'.");
+                return bad;
+            }
+
+            var id = idValues.ToString();
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+                await bad.WriteStringAsync("Invalid 'id' value.");
+                return bad;
+            }
+
+            _logger.LogInformation("DownloadReportRawData invoked for report {ReportId}", id);
+
+            await _reportStorage.EnsureInitializedAsync();
+            var blobClient = _reportStorage.RedditReportDataContainer.GetBlobClient($"{id}.json");
+
+            if (!await blobClient.ExistsAsync())
+            {
+                var notFound = req.CreateResponse(HttpStatusCode.NotFound);
+                await notFound.WriteStringAsync("No raw data found for the specified report.");
+                return notFound;
+            }
+
+            var content = await blobClient.DownloadContentAsync();
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+            response.Headers.Add("Content-Disposition", $"attachment; filename=\"reddit-report-{id}.json\"");
+            await response.WriteBytesAsync(content.Value.Content.ToArray());
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in DownloadReportRawData endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to download report raw data. Please try again later.");
+            return error;
+        }
+    }
+
+    /// <summary>
+    /// Ensures the caller is an authenticated admin. Returns an error response when not authorized,
+    /// otherwise returns null.
+    /// </summary>
+    private async Task<HttpResponseData?> EnsureAdminAsync(HttpRequestData req)
+    {
+        var authenticatedUser = await _authMiddleware.GetUserAsync(req);
+        if (authenticatedUser is null)
+        {
+            var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+            await unauthorized.WriteStringAsync("Authentication required");
+            return unauthorized;
+        }
+
+        var userAccount = await _userAccountService.GetUserAccountAsync(authenticatedUser.UserId);
+        if (userAccount?.Tier != AccountTier.Admin)
+        {
+            var forbidden = req.CreateResponse(HttpStatusCode.Forbidden);
+            await forbidden.WriteStringAsync("Admin access required");
+            return forbidden;
+        }
+
+        return null;
+    }
+}

--- a/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
+++ b/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -61,25 +62,46 @@ public class ReportDataAdminFunctions
             var reports = await _cacheService.GetReportsAsync("reddit", null);
             await _reportStorage.EnsureInitializedAsync();
 
-            // Determine which reports have raw data available
-            var rawDataIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            await foreach (var blob in _reportStorage.RedditReportDataContainer.GetBlobsAsync())
+            // Determine which reports have raw data available and read the captured totals
+            // (stored as blob metadata) so the list reflects the full downloadable dataset.
+            var rawDataInfo = new Dictionary<string, (int ThreadCount, int CommentCount)>(StringComparer.OrdinalIgnoreCase);
+            await foreach (var blob in _reportStorage.RedditReportDataContainer.GetBlobsAsync(BlobTraits.Metadata))
             {
-                rawDataIds.Add(Path.GetFileNameWithoutExtension(blob.Name));
+                var blobId = Path.GetFileNameWithoutExtension(blob.Name);
+                var threadCount = 0;
+                var commentCount = 0;
+                if (blob.Metadata is not null)
+                {
+                    if (blob.Metadata.TryGetValue("threadCount", out var tc))
+                    {
+                        int.TryParse(tc, out threadCount);
+                    }
+                    if (blob.Metadata.TryGetValue("commentCount", out var cc))
+                    {
+                        int.TryParse(cc, out commentCount);
+                    }
+                }
+                rawDataInfo[blobId] = (threadCount, commentCount);
             }
 
             var items = reports
                 .OrderByDescending(r => r.GeneratedAt)
-                .Select(r => new ReportDataListItem
+                .Select(r =>
                 {
-                    Id = r.Id,
-                    Source = r.Source,
-                    SubSource = r.SubSource,
-                    GeneratedAt = r.GeneratedAt,
-                    CutoffDate = r.CutoffDate,
-                    ThreadCount = r.ThreadCount,
-                    CommentCount = r.CommentCount,
-                    HasRawData = rawDataIds.Contains(r.Id.ToString())
+                    var hasRaw = rawDataInfo.TryGetValue(r.Id.ToString(), out var rawCounts);
+                    return new ReportDataListItem
+                    {
+                        Id = r.Id,
+                        Source = r.Source,
+                        SubSource = r.SubSource,
+                        GeneratedAt = r.GeneratedAt,
+                        CutoffDate = r.CutoffDate,
+                        // Prefer the full raw-data totals; fall back to the report's analyzed
+                        // counts for older reports captured before raw data was stored.
+                        ThreadCount = hasRaw && rawCounts.ThreadCount > 0 ? rawCounts.ThreadCount : r.ThreadCount,
+                        CommentCount = hasRaw && rawCounts.CommentCount > 0 ? rawCounts.CommentCount : r.CommentCount,
+                        HasRawData = hasRaw
+                    };
                 })
                 .ToList();
 

--- a/feedbackfunctions/Services/Reports/IReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/IReportStorageService.cs
@@ -11,6 +11,8 @@ public interface IReportStorageService
 
     BlobContainerClient WeeklySummariesContainer { get; }
 
+    BlobContainerClient RedditReportDataContainer { get; }
+
     TableClient ReportRequestsTable { get; }
 
     TableClient UserReportRequestsTable { get; }

--- a/feedbackfunctions/Services/Reports/ReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/ReportStorageService.cs
@@ -24,6 +24,8 @@ public class ReportStorageService : IReportStorageService
 
     public BlobContainerClient WeeklySummariesContainer => _storage.WeeklySummariesContainer;
 
+    public BlobContainerClient RedditReportDataContainer => _storage.RedditReportDataContainer;
+
     public TableClient ReportRequestsTable => _storage.ReportRequestsTable;
 
     public TableClient UserReportRequestsTable => _storage.UserReportRequestsTable;

--- a/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
+++ b/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
@@ -15,6 +15,7 @@ public class FeedbackStorageClients
             blobServiceClient.GetBlobContainerClient(StorageNames.ReportsSummaryContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.WeeklySummariesContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.SharedAnalysesContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.RedditReportDataContainer),
             tableServiceClient.GetTableClient(StorageNames.UserAccountsTable),
             tableServiceClient.GetTableClient(StorageNames.UsageRecordsTable),
             tableServiceClient.GetTableClient(StorageNames.ApiKeysTable),
@@ -33,6 +34,7 @@ public class FeedbackStorageClients
         BlobContainerClient reportsSummaryContainer,
         BlobContainerClient weeklySummariesContainer,
         BlobContainerClient sharedAnalysesContainer,
+        BlobContainerClient redditReportDataContainer,
         TableClient userAccountsTable,
         TableClient usageRecordsTable,
         TableClient apiKeysTable,
@@ -48,6 +50,7 @@ public class FeedbackStorageClients
         ReportsSummaryContainer = reportsSummaryContainer;
         WeeklySummariesContainer = weeklySummariesContainer;
         SharedAnalysesContainer = sharedAnalysesContainer;
+        RedditReportDataContainer = redditReportDataContainer;
         UserAccountsTable = userAccountsTable;
         UsageRecordsTable = usageRecordsTable;
         ApiKeysTable = apiKeysTable;
@@ -69,6 +72,8 @@ public class FeedbackStorageClients
     public BlobContainerClient WeeklySummariesContainer { get; }
 
     public BlobContainerClient SharedAnalysesContainer { get; }
+
+    public BlobContainerClient RedditReportDataContainer { get; }
 
     public TableClient UserAccountsTable { get; }
 

--- a/feedbackfunctions/Services/Storage/StorageNames.cs
+++ b/feedbackfunctions/Services/Storage/StorageNames.cs
@@ -6,6 +6,7 @@ public static class StorageNames
     public const string ReportsSummaryContainer = "reports-summary";
     public const string WeeklySummariesContainer = "weekly-summaries";
     public const string SharedAnalysesContainer = "shared-analyses";
+    public const string RedditReportDataContainer = "reddit-report-data";
 
     public const string UserAccountsTable = "UserAccounts";
     public const string UsageRecordsTable = "UsageRecords";

--- a/feedbackfunctions/Services/Storage/TableInitializationService.cs
+++ b/feedbackfunctions/Services/Storage/TableInitializationService.cs
@@ -39,7 +39,8 @@ public class TableInitializationService : ITableInitializationService
                 _storage.UserReportRequestsTable.CreateIfNotExistsAsync(),
                 _storage.ReportsContainer.CreateIfNotExistsAsync(),
                 _storage.ReportsSummaryContainer.CreateIfNotExistsAsync(),
-                _storage.WeeklySummariesContainer.CreateIfNotExistsAsync());
+                _storage.WeeklySummariesContainer.CreateIfNotExistsAsync(),
+                _storage.RedditReportDataContainer.CreateIfNotExistsAsync());
         });
 
     public Task EnsureAdminReportConfigsAsync() =>

--- a/feedbackfunctions/Utils/ReportGenerator.cs
+++ b/feedbackfunctions/Utils/ReportGenerator.cs
@@ -185,7 +185,21 @@ Keep each section very brief and focused. Total analysis should be no more than 
             if (storeToBlob.HasValue && storeToBlob.Value)
             {
                 await StoreReportAsync(report);
-                
+
+                // Store the raw fetched data (threads + comments + subreddit info) for later download
+                var rawData = new RedditReportRawData
+                {
+                    ReportId = report.Id,
+                    Subreddit = subreddit,
+                    GeneratedAt = report.GeneratedAt,
+                    CutoffDate = report.CutoffDate,
+                    ThreadCount = topThreads.Count,
+                    CommentCount = allComments.Count,
+                    SubredditInfo = subredditInfo,
+                    Threads = results.Select(r => r.Thread).ToList()
+                };
+                await StoreRedditRawDataAsync(rawData);
+
                 // Also create and store a summary report
                 _logger.LogInformation("Generating summary report for r/{Subreddit}", subreddit);
                 var summaryReport = new ReportModel
@@ -429,6 +443,36 @@ Keep each section very brief and focused. Total analysis should be no more than 
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error storing report {ReportId} to blob storage", report.Id);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Stores the raw fetched Reddit data (threads + comments + subreddit info) in blob storage
+    /// </summary>
+    /// <param name="rawData">The raw data to store, keyed by the report id</param>
+    /// <returns>The blob name where the raw data was stored</returns>
+    public async Task<string> StoreRedditRawDataAsync(RedditReportRawData rawData)
+    {
+        _logger.LogInformation("Storing raw Reddit data for report {ReportId} to blob storage", rawData.ReportId);
+        await _reportStorage.EnsureInitializedAsync();
+
+        try
+        {
+            var blobName = $"{rawData.ReportId}.json";
+            var blobClient = _reportStorage.RedditReportDataContainer.GetBlobClient(blobName);
+
+            var rawJson = JsonSerializer.Serialize(rawData);
+            await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
+            await blobClient.UploadAsync(ms, overwrite: true);
+
+            _logger.LogInformation("Successfully stored raw Reddit data for report {ReportId} as blob {BlobName}",
+                rawData.ReportId, blobName);
+            return blobName;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error storing raw Reddit data for report {ReportId} to blob storage", rawData.ReportId);
             throw;
         }
     }

--- a/feedbackfunctions/Utils/ReportGenerator.cs
+++ b/feedbackfunctions/Utils/ReportGenerator.cs
@@ -186,19 +186,72 @@ Keep each section very brief and focused. Total analysis should be no more than 
             {
                 await StoreReportAsync(report);
 
-                // Store the raw fetched data (threads + comments + subreddit info) for later download
-                var rawData = new RedditReportRawData
+                // Store the raw fetched data for later download. Unlike the report itself (which
+                // only analyzes the top threads), the raw data captures EVERY thread from the last
+                // week along with all of its comments so nothing is lost.
+                try
                 {
-                    ReportId = report.Id,
-                    Subreddit = subreddit,
-                    GeneratedAt = report.GeneratedAt,
-                    CutoffDate = report.CutoffDate,
-                    ThreadCount = topThreads.Count,
-                    CommentCount = allComments.Count,
-                    SubredditInfo = subredditInfo,
-                    Threads = results.Select(r => r.Thread).ToList()
-                };
-                await StoreRedditRawDataAsync(rawData);
+                    // Reuse the full threads already fetched for analysis, then fetch the rest.
+                    var fullThreadsById = results
+                        .Select(r => r.Thread)
+                        .GroupBy(t => t.Id)
+                        .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+                    var remainingThreads = threads
+                        .Where(t => !fullThreadsById.ContainsKey(t.Id))
+                        .ToList();
+
+                    _logger.LogInformation(
+                        "Capturing complete raw data: fetching full comments for {RemainingCount} additional threads (total {TotalCount} threads from the last week)",
+                        remainingThreads.Count, threads.Count);
+
+                    // Bound concurrency to avoid hammering the Reddit API / hitting rate limits.
+                    using var throttler = new SemaphoreSlim(5);
+                    var remainingTasks = remainingThreads.Select(async t =>
+                    {
+                        await throttler.WaitAsync();
+                        try
+                        {
+                            return await _redditService.GetThreadWithComments(t.Id);
+                        }
+                        finally
+                        {
+                            throttler.Release();
+                        }
+                    }).ToList();
+
+                    var remainingFullThreads = await Task.WhenAll(remainingTasks);
+                    foreach (var fullThread in remainingFullThreads)
+                    {
+                        fullThreadsById[fullThread.Id] = fullThread;
+                    }
+
+                    // Preserve the original listing order from the subreddit.
+                    var allFullThreads = threads
+                        .Where(t => fullThreadsById.ContainsKey(t.Id))
+                        .Select(t => fullThreadsById[t.Id])
+                        .ToList();
+
+                    var totalRawCommentCount = allFullThreads.Sum(t => FlattenComments(t.Comments).Count);
+
+                    var rawData = new RedditReportRawData
+                    {
+                        ReportId = report.Id,
+                        Subreddit = subreddit,
+                        GeneratedAt = report.GeneratedAt,
+                        CutoffDate = report.CutoffDate,
+                        ThreadCount = allFullThreads.Count,
+                        CommentCount = totalRawCommentCount,
+                        SubredditInfo = subredditInfo,
+                        Threads = allFullThreads
+                    };
+                    await StoreRedditRawDataAsync(rawData);
+                }
+                catch (Exception rawEx)
+                {
+                    // Raw data capture is best-effort; never fail the report because of it.
+                    _logger.LogError(rawEx, "Failed to capture/store complete raw Reddit data for report {ReportId}", report.Id);
+                }
 
                 // Also create and store a summary report
                 _logger.LogInformation("Generating summary report for r/{Subreddit}", subreddit);
@@ -465,6 +518,14 @@ Keep each section very brief and focused. Total analysis should be no more than 
             var rawJson = JsonSerializer.Serialize(rawData);
             await using var ms = new MemoryStream(Encoding.UTF8.GetBytes(rawJson));
             await blobClient.UploadAsync(ms, overwrite: true);
+
+            // Persist lightweight counts as blob metadata so the admin report-data list can
+            // surface accurate totals without downloading the (potentially large) raw blob.
+            await blobClient.SetMetadataAsync(new Dictionary<string, string>
+            {
+                ["threadCount"] = rawData.ThreadCount.ToString(),
+                ["commentCount"] = rawData.CommentCount.ToString()
+            });
 
             _logger.LogInformation("Successfully stored raw Reddit data for report {ReportId} as blob {BlobName}",
                 rawData.ReportId, blobName);

--- a/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
+++ b/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
@@ -36,6 +36,13 @@
                     <div class="desc">Automation</div>
                 </a>
             </div>
+            <div class="col-6 col-md-3">
+                <a href="/admin/report-data" class="admin-feature-tile d-block text-decoration-none">
+                    <div class="icon-wrapper"><i class="bi bi-database-down"></i></div>
+                    <div class="title">Report Data</div>
+                    <div class="desc">Browse & download</div>
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
@@ -1,0 +1,235 @@
+@page "/admin/report-data"
+@using FeedbackWebApp.Services
+@using FeedbackWebApp.Services.Authentication
+@using FeedbackWebApp.Services.Account
+@using SharedDump.Models.Reports
+@using SharedDump.Models.Account
+@using Microsoft.JSInterop
+@inject FeedbackWebApp.Services.IReportDataAdminService ReportDataAdminService
+@inject IAuthenticationService AuthService
+@inject IAccountServiceProvider AccountServiceProvider
+@inject IToastService ToastService
+@inject IJSRuntime JSRuntime
+@inject NavigationManager Navigation
+
+@using FeedbackWebApp.Components.Admin
+@namespace FeedbackWebApp.Components.Pages.Admin
+
+<PageTitle>Report Data - FeedbackFlow</PageTitle>
+
+<div class="container my-4">
+    <div class="mb-3">
+        <a href="/admin" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-arrow-left me-1"></i> Back to Admin Home
+        </a>
+    </div>
+
+    @if (isLoading)
+    {
+        <AdminLoadingSpinner LoadingTitle="Report Data"
+                           LoadingMessage="Loading generated reports and raw data availability..."
+                           SpinnerIcon="bi-database-down" />
+    }
+    else if (!isAdmin)
+    {
+        <div class="alert alert-danger" role="alert">
+            <i class="bi bi-shield-exclamation me-2"></i>
+            <strong>Access Denied:</strong> This page is only available to administrators.
+        </div>
+    }
+    else
+    {
+        <div class="d-flex justify-content-between align-items-center mb-4 admin-header">
+            <div>
+                <h1 class="feedbackflow-title mb-2">
+                    <i class="bi bi-database-down me-2"></i>
+                    Report Data
+                </h1>
+                <p class="text-muted mb-0">Browse all generated reports and download their raw data</p>
+            </div>
+            <button class="btn btn-outline-primary" @onclick="LoadReports" disabled="@isRefreshing">
+                <i class="bi bi-arrow-clockwise me-2"></i>
+                Refresh
+            </button>
+        </div>
+
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <div class="alert alert-danger" role="alert">
+                <i class="bi bi-exclamation-triangle me-2"></i>
+                @errorMessage
+            </div>
+        }
+
+        @if (reports.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">
+                <i class="bi bi-info-circle me-2"></i>
+                No generated reports found.
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover align-middle admin-report-data-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Subreddit</th>
+                            <th scope="col" class="d-none d-md-table-cell">Generated</th>
+                            <th scope="col" class="text-center d-none d-sm-table-cell">Threads</th>
+                            <th scope="col" class="text-center d-none d-sm-table-cell">Comments</th>
+                            <th scope="col" class="d-none d-lg-table-cell">Cutoff</th>
+                            <th scope="col" class="text-center">Raw Data</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var report in reports)
+                        {
+                            <tr @key="report.Id">
+                                <td>
+                                    <div class="item-name">
+                                        <i class="bi bi-reddit me-1"></i>
+                                        r/@report.SubSource
+                                    </div>
+                                </td>
+                                <td class="d-none d-md-table-cell">
+                                    <span class="item-date">
+                                        <i class="bi bi-calendar me-1"></i>
+                                        @report.GeneratedAt.ToLocalTime().ToString("g")
+                                    </span>
+                                </td>
+                                <td class="text-center d-none d-sm-table-cell">@report.ThreadCount</td>
+                                <td class="text-center d-none d-sm-table-cell">@report.CommentCount</td>
+                                <td class="d-none d-lg-table-cell">
+                                    <span class="item-date">
+                                        <i class="bi bi-clock-history me-1"></i>
+                                        @report.CutoffDate.ToLocalTime().ToString("d")
+                                    </span>
+                                </td>
+                                <td class="text-center">
+                                    <div class="action-buttons">
+                                        @if (report.HasRawData)
+                                        {
+                                            <button class="btn btn-sm btn-outline-primary"
+                                                    title="Download raw data"
+                                                    disabled="@(downloadingId == report.Id)"
+                                                    @onclick="() => DownloadRawData(report)">
+                                                @if (downloadingId == report.Id)
+                                                {
+                                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                }
+                                                else
+                                                {
+                                                    <i class="bi bi-download"></i>
+                                                }
+                                                <span class="ms-1 d-none d-md-inline">Download</span>
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <span class="status-badge status-unavailable" title="No raw data was captured for this report">
+                                                <i class="bi bi-dash-circle"></i>
+                                                N/A
+                                            </span>
+                                        }
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    }
+</div>
+
+@code {
+    private bool isLoading = true;
+    private bool isAdmin = false;
+    private bool isRefreshing = false;
+    private string errorMessage = string.Empty;
+    private List<ReportDataListItem> reports = new();
+    private Guid? downloadingId = null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            isLoading = true;
+            errorMessage = string.Empty;
+
+            var isAuthenticated = await AuthService.IsAuthenticatedAsync();
+            if (!isAuthenticated)
+            {
+                Navigation.NavigateTo("/");
+                return;
+            }
+
+            var accountService = AccountServiceProvider.GetService();
+            var accountResult = await accountService.GetUserAccountAndLimitsAsync();
+            if (accountResult.HasValue)
+            {
+                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+            }
+
+            if (isAdmin)
+            {
+                await LoadReports();
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error loading report data: {ex.Message}";
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task LoadReports()
+    {
+        try
+        {
+            isRefreshing = true;
+            errorMessage = string.Empty;
+            reports = await ReportDataAdminService.GetAllReportsAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error loading reports: {ex.Message}";
+        }
+        finally
+        {
+            isRefreshing = false;
+        }
+    }
+
+    private async Task DownloadRawData(ReportDataListItem report)
+    {
+        try
+        {
+            downloadingId = report.Id;
+            var json = await ReportDataAdminService.DownloadRawDataAsync(report.Id);
+            if (string.IsNullOrEmpty(json))
+            {
+                await ToastService.ShowErrorAsync("No raw data available for this report.");
+                return;
+            }
+
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
+            var dataUrl = $"data:application/json;base64,{base64}";
+            var fileName = $"reddit-report-{report.SubSource}-{report.Id}.json";
+
+            await JSRuntime.InvokeAsync<bool>("downloadFile", dataUrl, fileName);
+        }
+        catch (Exception ex)
+        {
+            await ToastService.ShowErrorAsync($"Failed to download raw data: {ex.Message}");
+        }
+        finally
+        {
+            downloadingId = null;
+        }
+    }
+}

--- a/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
@@ -79,7 +79,7 @@
                             <th scope="col" class="text-center d-none d-sm-table-cell">Threads</th>
                             <th scope="col" class="text-center d-none d-sm-table-cell">Comments</th>
                             <th scope="col" class="d-none d-lg-table-cell">Cutoff</th>
-                            <th scope="col" class="text-center">Raw Data</th>
+                            <th scope="col" class="text-center">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -108,6 +108,12 @@
                                 </td>
                                 <td class="text-center">
                                     <div class="action-buttons">
+                                        <a class="btn btn-sm btn-outline-secondary"
+                                           href="/report/@report.Id"
+                                           title="View report">
+                                            <i class="bi bi-file-earmark-text"></i>
+                                            <span class="ms-1 d-none d-md-inline">Report</span>
+                                        </a>
                                         @if (report.HasRawData)
                                         {
                                             <button class="btn btn-sm btn-outline-primary"
@@ -122,7 +128,7 @@
                                                 {
                                                     <i class="bi bi-download"></i>
                                                 }
-                                                <span class="ms-1 d-none d-md-inline">Download</span>
+                                                <span class="ms-1 d-none d-md-inline">Raw Data</span>
                                             </button>
                                         }
                                         else

--- a/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor.css
+++ b/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor.css
@@ -1,0 +1,84 @@
+.admin-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.admin-report-data-table {
+    width: 100%;
+    margin-bottom: 0;
+    background: var(--card-bg);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.admin-report-data-table th {
+    background: rgba(var(--bg-secondary-rgb), 0.8);
+    color: var(--text-primary);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    letter-spacing: 0.5px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.admin-report-data-table td {
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-color);
+    transition: background-color 0.3s ease;
+}
+
+.admin-report-data-table tbody tr:hover td {
+    background: linear-gradient(135deg, rgba(var(--primary-color-rgb), 0.05) 0%, rgba(var(--primary-color-rgb), 0.1) 100%);
+}
+
+.item-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+}
+
+.item-name .bi-reddit {
+    color: #ff4500;
+}
+
+.item-date {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    display: inline-flex;
+    align-items: center;
+}
+
+.action-buttons {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--border-radius-pill);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    gap: 0.25rem;
+    transition: all 0.3s ease;
+}
+
+.status-unavailable {
+    background: rgba(var(--bg-secondary-rgb), 0.6);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+}
+
+/* Responsive adjustments */
+@media (max-width: 767.98px) {
+    .admin-report-data-table th,
+    .admin-report-data-table td {
+        font-size: 0.85rem;
+    }
+}

--- a/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor.css
+++ b/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor.css
@@ -6,6 +6,10 @@
 .admin-report-data-table {
     width: 100%;
     margin-bottom: 0;
+    /* Override Bootstrap's table CSS variables so cells follow the app theme
+       instead of defaulting to a white background in dark mode. */
+    --bs-table-bg: transparent;
+    --bs-table-color: var(--text-primary);
     background: var(--card-bg);
     border-radius: var(--border-radius);
     overflow: hidden;
@@ -22,6 +26,7 @@
 }
 
 .admin-report-data-table td {
+    background: var(--card-bg);
     color: var(--text-primary);
     border-bottom: 1px solid var(--border-color);
     transition: background-color 0.3s ease;
@@ -29,6 +34,10 @@
 
 .admin-report-data-table tbody tr:hover td {
     background: linear-gradient(135deg, rgba(var(--primary-color-rgb), 0.05) 0%, rgba(var(--primary-color-rgb), 0.1) 100%);
+}
+
+.admin-report-data-table tbody tr:last-child td {
+    border-bottom: none;
 }
 
 .item-name {

--- a/feedbackwebapp/Program.cs
+++ b/feedbackwebapp/Program.cs
@@ -96,6 +96,24 @@ builder.Services.AddScoped<FeedbackWebApp.Services.IAdminReportConfigService>(se
     }
 });
 
+// Register Admin Report Data Service
+builder.Services.AddScoped<FeedbackWebApp.Services.IReportDataAdminService>(serviceProvider =>
+{
+    if (useMocks)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<FeedbackWebApp.Services.Mock.MockReportDataAdminService>>();
+        return new FeedbackWebApp.Services.Mock.MockReportDataAdminService(logger);
+    }
+    else
+    {
+        var httpClient = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("DefaultClient");
+        var headerService = serviceProvider.GetRequiredService<IAuthenticationHeaderService>();
+        var logger = serviceProvider.GetRequiredService<ILogger<ReportDataAdminService>>();
+        var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        return new ReportDataAdminService(httpClient, headerService, logger, configuration);
+    }
+});
+
 // Register Admin Dashboard Service
 builder.Services.AddScoped<IAdminDashboardService>(serviceProvider =>
 {

--- a/feedbackwebapp/Services/IReportDataAdminService.cs
+++ b/feedbackwebapp/Services/IReportDataAdminService.cs
@@ -1,0 +1,20 @@
+using SharedDump.Models.Reports;
+
+namespace FeedbackWebApp.Services;
+
+/// <summary>
+/// Web application service for the admin report-data portal. Lists all generated reports
+/// and downloads the raw fetched data for a given report from the Azure Functions backend.
+/// </summary>
+public interface IReportDataAdminService
+{
+    /// <summary>
+    /// Gets metadata for all generated reports available in the system.
+    /// </summary>
+    Task<List<ReportDataListItem>> GetAllReportsAsync();
+
+    /// <summary>
+    /// Downloads the raw JSON data for the specified report. Returns null when no raw data exists.
+    /// </summary>
+    Task<string?> DownloadRawDataAsync(Guid reportId);
+}

--- a/feedbackwebapp/Services/Mock/MockReportDataAdminService.cs
+++ b/feedbackwebapp/Services/Mock/MockReportDataAdminService.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using SharedDump.Models.Reports;
+
+namespace FeedbackWebApp.Services.Mock;
+
+/// <summary>
+/// Mock implementation of <see cref="IReportDataAdminService"/> for local development and tests.
+/// </summary>
+public class MockReportDataAdminService : IReportDataAdminService
+{
+    private readonly ILogger<MockReportDataAdminService> _logger;
+
+    private readonly List<ReportDataListItem> _reports = new()
+    {
+        new ReportDataListItem
+        {
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Source = "reddit",
+            SubSource = "dotnet",
+            GeneratedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            CutoffDate = DateTimeOffset.UtcNow.AddDays(-8),
+            ThreadCount = 5,
+            CommentCount = 120,
+            HasRawData = true
+        },
+        new ReportDataListItem
+        {
+            Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Source = "reddit",
+            SubSource = "csharp",
+            GeneratedAt = DateTimeOffset.UtcNow.AddDays(-3),
+            CutoffDate = DateTimeOffset.UtcNow.AddDays(-10),
+            ThreadCount = 3,
+            CommentCount = 64,
+            HasRawData = false
+        }
+    };
+
+    public MockReportDataAdminService(ILogger<MockReportDataAdminService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<List<ReportDataListItem>> GetAllReportsAsync()
+    {
+        await Task.Delay(200);
+        _logger.LogInformation("Mock: Returning {Count} sample reports", _reports.Count);
+        return _reports.ToList();
+    }
+
+    public async Task<string?> DownloadRawDataAsync(Guid reportId)
+    {
+        await Task.Delay(200);
+        var report = _reports.FirstOrDefault(r => r.Id == reportId);
+        if (report is null || !report.HasRawData)
+        {
+            _logger.LogInformation("Mock: No raw data for report {ReportId}", reportId);
+            return null;
+        }
+
+        var rawData = new RedditReportRawData
+        {
+            ReportId = report.Id,
+            Subreddit = report.SubSource,
+            GeneratedAt = report.GeneratedAt,
+            CutoffDate = report.CutoffDate,
+            ThreadCount = report.ThreadCount,
+            CommentCount = report.CommentCount
+        };
+
+        return JsonSerializer.Serialize(rawData, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/feedbackwebapp/Services/ReportDataAdminService.cs
+++ b/feedbackwebapp/Services/ReportDataAdminService.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Text.Json;
+using SharedDump.Models.Reports;
+using FeedbackWebApp.Services.Authentication;
+
+namespace FeedbackWebApp.Services;
+
+/// <summary>
+/// Communicates with the Azure Functions backend to list generated reports and download
+/// their raw data for the admin report-data portal.
+///
+/// API Endpoints:
+/// - GET /api/GetAllReports                  - List all generated reports (metadata)
+/// - GET /api/DownloadReportRawData?id={id}  - Download raw JSON data for a report
+/// </summary>
+public class ReportDataAdminService : IReportDataAdminService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IAuthenticationHeaderService _headerService;
+    private readonly ILogger<ReportDataAdminService> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _baseUrl;
+    private readonly string _functionsKey;
+
+    public ReportDataAdminService(
+        HttpClient httpClient,
+        IAuthenticationHeaderService headerService,
+        ILogger<ReportDataAdminService> logger,
+        IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _headerService = headerService;
+        _logger = logger;
+        _baseUrl = configuration["FeedbackApi:BaseUrl"]
+            ?? throw new InvalidOperationException("FeedbackApi:BaseUrl not configured");
+        _functionsKey = configuration["FeedbackApi:FunctionsKey"]
+            ?? throw new InvalidOperationException("FeedbackApi:FunctionsKey not configured");
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<List<ReportDataListItem>> GetAllReportsAsync()
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_baseUrl}/api/GetAllReports?code={Uri.EscapeDataString(_functionsKey)}");
+            await _headerService.AddAuthenticationHeadersAsync(request);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<ReportDataListResponse>(content, _jsonOptions);
+                return result?.Reports ?? new List<ReportDataListItem>();
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var statusCodeMessage = response.StatusCode switch
+            {
+                HttpStatusCode.Unauthorized => "Authentication required",
+                HttpStatusCode.Forbidden => "Admin access required",
+                _ => $"Server error ({response.StatusCode})"
+            };
+
+            _logger.LogError("Failed to get all reports. Status: {StatusCode}, Error: {Error}",
+                response.StatusCode, errorContent);
+            throw new InvalidOperationException($"Failed to get reports: {statusCodeMessage}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting all reports");
+            throw;
+        }
+    }
+
+    public async Task<string?> DownloadRawDataAsync(Guid reportId)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_baseUrl}/api/DownloadReportRawData?id={Uri.EscapeDataString(reportId.ToString())}&code={Uri.EscapeDataString(_functionsKey)}");
+            await _headerService.AddAuthenticationHeadersAsync(request);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync();
+            _logger.LogError("Failed to download raw data for report {ReportId}. Status: {StatusCode}, Error: {Error}",
+                reportId, response.StatusCode, errorContent);
+            throw new InvalidOperationException($"Failed to download raw data ({response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error downloading raw data for report {ReportId}", reportId);
+            throw;
+        }
+    }
+}

--- a/shareddump/Models/Reports/RedditReportRawData.cs
+++ b/shareddump/Models/Reports/RedditReportRawData.cs
@@ -46,7 +46,8 @@ public class RedditReportRawData
     public RedditSubredditInfo? SubredditInfo { get; set; }
 
     /// <summary>
-    /// The full threads (including nested comments) that were analyzed for the report.
+    /// The full threads (including nested comments) captured from the last week.
+    /// Includes every thread from the report's time window, not just the analyzed top threads.
     /// </summary>
     public List<RedditThreadModel> Threads { get; set; } = new();
 }

--- a/shareddump/Models/Reports/RedditReportRawData.cs
+++ b/shareddump/Models/Reports/RedditReportRawData.cs
@@ -1,0 +1,52 @@
+using SharedDump.Models.Reddit;
+
+namespace SharedDump.Models.Reports;
+
+/// <summary>
+/// Raw, unprocessed Reddit data captured at the time a Reddit report was generated.
+/// Stored as a single JSON blob (keyed by <see cref="ReportId"/>) so the underlying
+/// threads and comments that fed a report can be inspected or downloaded later.
+/// Contains the fetched data only (threads, comments, subreddit info) - no AI analyses.
+/// </summary>
+public class RedditReportRawData
+{
+    /// <summary>
+    /// Identifier of the <see cref="ReportModel"/> this raw data belongs to.
+    /// </summary>
+    public Guid ReportId { get; set; }
+
+    /// <summary>
+    /// The subreddit the report was generated for (without the "r/" prefix).
+    /// </summary>
+    public string Subreddit { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When the report (and this raw data) was generated.
+    /// </summary>
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// The cutoff date used when fetching threads for the report.
+    /// </summary>
+    public DateTimeOffset CutoffDate { get; set; }
+
+    /// <summary>
+    /// Number of threads captured in this raw data set.
+    /// </summary>
+    public int ThreadCount { get; set; }
+
+    /// <summary>
+    /// Total number of comments captured across all threads.
+    /// </summary>
+    public int CommentCount { get; set; }
+
+    /// <summary>
+    /// Metadata about the subreddit at the time of capture.
+    /// </summary>
+    public RedditSubredditInfo? SubredditInfo { get; set; }
+
+    /// <summary>
+    /// The full threads (including nested comments) that were analyzed for the report.
+    /// </summary>
+    public List<RedditThreadModel> Threads { get; set; } = new();
+}

--- a/shareddump/Models/Reports/ReportDataListItem.cs
+++ b/shareddump/Models/Reports/ReportDataListItem.cs
@@ -1,0 +1,28 @@
+namespace SharedDump.Models.Reports;
+
+/// <summary>
+/// Lightweight metadata describing a generated report for the admin report-data portal.
+/// </summary>
+public class ReportDataListItem
+{
+    public Guid Id { get; set; }
+    public string Source { get; set; } = string.Empty;
+    public string SubSource { get; set; } = string.Empty;
+    public DateTimeOffset GeneratedAt { get; set; }
+    public DateTimeOffset CutoffDate { get; set; }
+    public int ThreadCount { get; set; }
+    public int CommentCount { get; set; }
+
+    /// <summary>
+    /// Whether downloadable raw data exists for this report.
+    /// </summary>
+    public bool HasRawData { get; set; }
+}
+
+/// <summary>
+/// Response payload for the admin report listing endpoint.
+/// </summary>
+public class ReportDataListResponse
+{
+    public List<ReportDataListItem> Reports { get; set; } = new();
+}


### PR DESCRIPTION
## Why

When we generate weekly Reddit reports, we fetch the full threads and all their comments, build an HTML report, and then throw the raw data away. That underlying data is valuable, so this change captures it and makes it accessible to admins.

## What changed

**Capture raw data**
- New `reddit-report-data` blob container (wired through `StorageNames`, `FeedbackStorageClients`, `IReportStorageService`/`ReportStorageService`, and auto-created in `TableInitializationService`).
- New `RedditReportRawData` model holding the fetched data only: full threads + all comments + subreddit info (no AI analyses).
- `ReportGenerator.GenerateRedditReportAsync` now serializes this data to `{reportId}.json` whenever a report is stored. Because all generation paths (weekly processor, admin configs, on-demand) funnel through this method, they all get raw data captured automatically.

**Admin API** (`ReportDataAdminFunctions.cs`, admin-auth)
- `GetAllReports` lists generated Reddit report metadata with a `HasRawData` flag (computed by checking blob existence).
- `DownloadReportRawData?id=` streams the raw JSON as a file attachment; returns 404 when no raw data exists.

**Admin portal**
- New `/admin/report-data` page (with scoped, theme-aware CSS) showing a responsive table of all generated reports with a one-click Download button per row. Reports without raw data show a disabled "N/A" badge.
- New `IReportDataAdminService` (+ real impl and mock), registered conditionally via `useMocks`.
- Added a "Report Data" tile to the Admin home panel.

## Notes for reviewers

- Scope is intentionally Reddit-only for now and captures fetched data without AI analyses, per the request.
- Reports generated before this change have no raw-data blob, so the list degrades gracefully (download disabled, no errors).
- Download uses the existing `window.downloadFile` JS helper via a base64 data URL built server-side, so no new JS was needed.

## Validation

- `dotnet build FeedbackFlow.slnx` clean (0 errors).
- `dotnet test FeedbackFlow.slnx` -> 280 passed, 0 failed, 1 skipped. Updated `TableInitializationServiceTests` for the new container constructor arg.