### PR TITLE
[feedbackwebapp] Add admin Reddit subreddit export portal

### DIFF
--- a/feedbackflow.tests/TableInitializationServiceTests.cs
+++ b/feedbackflow.tests/TableInitializationServiceTests.cs
@@ -213,7 +213,8 @@ public class TableInitializationServiceTests
         BlobContainerClient? reportsSummaryContainer = null,
         BlobContainerClient? weeklySummariesContainer = null,
         BlobContainerClient? sharedAnalysesContainer = null,
-        BlobContainerClient? redditReportDataContainer = null)
+        BlobContainerClient? redditReportDataContainer = null,
+        BlobContainerClient? redditExportsContainer = null)
     {
         return new FeedbackStorageClients(
             blobServiceClient: null,
@@ -223,6 +224,7 @@ public class TableInitializationServiceTests
             weeklySummariesContainer: weeklySummariesContainer ?? Substitute.For<BlobContainerClient>(),
             sharedAnalysesContainer: sharedAnalysesContainer ?? Substitute.For<BlobContainerClient>(),
             redditReportDataContainer: redditReportDataContainer ?? Substitute.For<BlobContainerClient>(),
+            redditExportsContainer: redditExportsContainer ?? Substitute.For<BlobContainerClient>(),
             userAccountsTable: userAccountsTable ?? Substitute.For<TableClient>(),
             usageRecordsTable: usageRecordsTable ?? Substitute.For<TableClient>(),
             apiKeysTable: apiKeysTable ?? Substitute.For<TableClient>(),

--- a/feedbackfunctions/Reports/RedditExportFunctions.cs
+++ b/feedbackfunctions/Reports/RedditExportFunctions.cs
@@ -1,0 +1,440 @@
+using System.Net;
+using System.Text.Json;
+using Azure.Storage.Blobs.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using FeedbackFunctions.Attributes;
+using FeedbackFunctions.Middleware;
+using FeedbackFunctions.Services.Account;
+using FeedbackFunctions.Services.Reports;
+using SharedDump.Models.Account;
+using SharedDump.Models.Reddit;
+using SharedDump.Models.Reports;
+using SharedDump.Services.Interfaces;
+
+namespace FeedbackFunctions.Reports;
+
+/// <summary>
+/// Admin-only Azure Functions for creating, listing, downloading, and deleting on-demand
+/// subreddit exports (all threads + comments within a date range, stored as JSON blobs).
+/// </summary>
+public class RedditExportFunctions
+{
+    private const int MaxWindowDays = 7;
+    private const int MaxThreadCap = 500;
+    private const int DefaultThreadCap = 200;
+
+    private readonly ILogger<RedditExportFunctions> _logger;
+    private readonly AuthenticationMiddleware _authMiddleware;
+    private readonly IUserAccountService _userAccountService;
+    private readonly IReportStorageService _reportStorage;
+    private readonly IRedditService _redditService;
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public RedditExportFunctions(
+        ILogger<RedditExportFunctions> logger,
+        AuthenticationMiddleware authMiddleware,
+        IUserAccountService userAccountService,
+        IReportStorageService reportStorage,
+        IRedditService redditService)
+    {
+        _logger = logger;
+        _authMiddleware = authMiddleware;
+        _userAccountService = userAccountService;
+        _reportStorage = reportStorage;
+        _redditService = redditService;
+    }
+
+    /// <summary>
+    /// Creates a new subreddit export: fetches every thread (and its comments) created in the
+    /// requested window (capped), stores the result as a JSON blob, and returns its metadata.
+    /// </summary>
+    [Function("CreateRedditExport")]
+    [Authorize]
+    public async Task<HttpResponseData> CreateRedditExport(
+        [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            var body = await req.ReadAsStringAsync();
+            CreateRedditExportRequest? request = null;
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                request = JsonSerializer.Deserialize<CreateRedditExportRequest>(body, _jsonOptions);
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.Subreddit))
+            {
+                return await BadRequest(req, "A subreddit is required.");
+            }
+
+            var subreddit = request.Subreddit.Trim();
+            if (subreddit.StartsWith("r/", StringComparison.OrdinalIgnoreCase))
+            {
+                subreddit = subreddit[2..];
+            }
+            subreddit = subreddit.Trim('/').Trim();
+            if (string.IsNullOrWhiteSpace(subreddit))
+            {
+                return await BadRequest(req, "A valid subreddit is required.");
+            }
+
+            var startDate = request.StartDate.ToUniversalTime();
+            var endDate = request.EndDate.ToUniversalTime();
+
+            if (endDate <= startDate)
+            {
+                return await BadRequest(req, "The end date must be after the start date.");
+            }
+
+            if ((endDate - startDate).TotalDays > MaxWindowDays)
+            {
+                return await BadRequest(req, $"The date range cannot exceed {MaxWindowDays} days.");
+            }
+
+            var maxThreads = request.MaxThreads <= 0
+                ? DefaultThreadCap
+                : Math.Min(request.MaxThreads, MaxThreadCap);
+
+            _logger.LogInformation(
+                "CreateRedditExport invoked for r/{Subreddit} from {Start} to {End} (max {Max} threads)",
+                subreddit, startDate, endDate, maxThreads);
+
+            // Validate the subreddit exists before doing heavy work.
+            if (!await _redditService.CheckSubredditValid(subreddit))
+            {
+                return await BadRequest(req, $"Subreddit 'r/{subreddit}' was not found or is not accessible.");
+            }
+
+            RedditSubredditInfo? subredditInfo = null;
+            try
+            {
+                subredditInfo = await _redditService.GetSubredditInfo(subreddit);
+            }
+            catch (Exception infoEx)
+            {
+                _logger.LogWarning(infoEx, "Failed to fetch subreddit info for r/{Subreddit}", subreddit);
+            }
+
+            var (basicThreads, limitReached) = await _redditService.GetSubredditThreadsInDateRange(
+                subreddit, startDate, endDate, maxThreads);
+
+            _logger.LogInformation(
+                "Found {Count} threads in r/{Subreddit} for the window; fetching full comments",
+                basicThreads.Count, subreddit);
+
+            // Fetch full threads (with comments) using bounded concurrency to respect rate limits.
+            using var throttler = new SemaphoreSlim(5);
+            var tasks = basicThreads.Select(async basic =>
+            {
+                await throttler.WaitAsync();
+                try
+                {
+                    var full = await _redditService.GetThreadWithComments(basic.Id);
+                    // GetThreadWithComments does not always set the correct subreddit/created date.
+                    full.Subreddit = subreddit;
+                    if (full.CreatedUtc == default)
+                    {
+                        full.CreatedUtc = basic.CreatedUtc;
+                    }
+                    return full;
+                }
+                catch (Exception threadEx)
+                {
+                    _logger.LogWarning(threadEx, "Failed to fetch comments for thread {ThreadId}; skipping", basic.Id);
+                    return null;
+                }
+                finally
+                {
+                    throttler.Release();
+                }
+            }).ToList();
+
+            var fullThreads = (await Task.WhenAll(tasks))
+                .Where(t => t is not null)
+                .Select(t => t!)
+                .OrderByDescending(t => t.CreatedUtc)
+                .ToList();
+
+            var commentCount = fullThreads.Sum(t => CountComments(t.Comments));
+
+            var export = new RedditSubredditExport
+            {
+                Subreddit = subreddit,
+                StartDate = startDate,
+                EndDate = endDate,
+                GeneratedAt = DateTimeOffset.UtcNow,
+                ThreadCount = fullThreads.Count,
+                CommentCount = commentCount,
+                ThreadLimitReached = limitReached,
+                SubredditInfo = subredditInfo,
+                Threads = fullThreads
+            };
+
+            await StoreExportAsync(export);
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(ToListItem(export));
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in CreateRedditExport endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to create the subreddit export. Please try again later.");
+            return error;
+        }
+    }
+
+    /// <summary>
+    /// Lists all stored subreddit exports (metadata only), newest first.
+    /// </summary>
+    [Function("GetRedditExports")]
+    [Authorize]
+    public async Task<HttpResponseData> GetRedditExports(
+        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            await _reportStorage.EnsureInitializedAsync();
+
+            var items = new List<RedditExportListItem>();
+            await foreach (var blob in _reportStorage.RedditExportsContainer.GetBlobsAsync(BlobTraits.Metadata))
+            {
+                if (!Guid.TryParse(Path.GetFileNameWithoutExtension(blob.Name), out var id))
+                {
+                    continue;
+                }
+
+                var item = new RedditExportListItem { Id = id };
+                var meta = blob.Metadata;
+                if (meta is not null)
+                {
+                    if (meta.TryGetValue("subreddit", out var sub)) item.Subreddit = sub;
+                    if (meta.TryGetValue("threadCount", out var tc) && int.TryParse(tc, out var tcv)) item.ThreadCount = tcv;
+                    if (meta.TryGetValue("commentCount", out var cc) && int.TryParse(cc, out var ccv)) item.CommentCount = ccv;
+                    if (meta.TryGetValue("limitReached", out var lr) && bool.TryParse(lr, out var lrv)) item.ThreadLimitReached = lrv;
+                    if (meta.TryGetValue("startDate", out var sd) && DateTimeOffset.TryParse(sd, out var sdv)) item.StartDate = sdv;
+                    if (meta.TryGetValue("endDate", out var ed) && DateTimeOffset.TryParse(ed, out var edv)) item.EndDate = edv;
+                    if (meta.TryGetValue("generatedAt", out var ga) && DateTimeOffset.TryParse(ga, out var gav)) item.GeneratedAt = gav;
+                }
+
+                if (item.GeneratedAt == default && blob.Properties.CreatedOn.HasValue)
+                {
+                    item.GeneratedAt = blob.Properties.CreatedOn.Value;
+                }
+
+                items.Add(item);
+            }
+
+            var ordered = items.OrderByDescending(i => i.GeneratedAt).ToList();
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(new RedditExportListResponse { Exports = ordered });
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in GetRedditExports endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to retrieve exports. Please try again later.");
+            return error;
+        }
+    }
+
+    /// <summary>
+    /// Downloads the full JSON for a stored subreddit export.
+    /// </summary>
+    [Function("DownloadRedditExport")]
+    [Authorize]
+    public async Task<HttpResponseData> DownloadRedditExport(
+        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            if (!TryGetId(req, out var id))
+            {
+                return await BadRequest(req, "Missing or invalid 'id' query parameter.");
+            }
+
+            await _reportStorage.EnsureInitializedAsync();
+            var blobClient = _reportStorage.RedditExportsContainer.GetBlobClient($"{id}.json");
+
+            if (!await blobClient.ExistsAsync())
+            {
+                var notFound = req.CreateResponse(HttpStatusCode.NotFound);
+                await notFound.WriteStringAsync("No export found for the specified id.");
+                return notFound;
+            }
+
+            var content = await blobClient.DownloadContentAsync();
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+            response.Headers.Add("Content-Disposition", $"attachment; filename=\"reddit-export-{id}.json\"");
+            await response.WriteBytesAsync(content.Value.Content.ToArray());
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in DownloadRedditExport endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to download the export. Please try again later.");
+            return error;
+        }
+    }
+
+    /// <summary>
+    /// Deletes a stored subreddit export.
+    /// </summary>
+    [Function("DeleteRedditExport")]
+    [Authorize]
+    public async Task<HttpResponseData> DeleteRedditExport(
+        [HttpTrigger(AuthorizationLevel.Function, "delete")] HttpRequestData req)
+    {
+        try
+        {
+            var forbidden = await EnsureAdminAsync(req);
+            if (forbidden is not null)
+            {
+                return forbidden;
+            }
+
+            if (!TryGetId(req, out var id))
+            {
+                return await BadRequest(req, "Missing or invalid 'id' query parameter.");
+            }
+
+            await _reportStorage.EnsureInitializedAsync();
+            var blobClient = _reportStorage.RedditExportsContainer.GetBlobClient($"{id}.json");
+            var deleted = await blobClient.DeleteIfExistsAsync();
+
+            if (!deleted.Value)
+            {
+                var notFound = req.CreateResponse(HttpStatusCode.NotFound);
+                await notFound.WriteStringAsync("No export found for the specified id.");
+                return notFound;
+            }
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(new { success = true, id });
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in DeleteRedditExport endpoint");
+            var error = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await error.WriteStringAsync("Failed to delete the export. Please try again later.");
+            return error;
+        }
+    }
+
+    private async Task StoreExportAsync(RedditSubredditExport export)
+    {
+        await _reportStorage.EnsureInitializedAsync();
+
+        var blobClient = _reportStorage.RedditExportsContainer.GetBlobClient($"{export.Id}.json");
+        var json = JsonSerializer.Serialize(export);
+        await using var ms = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        await blobClient.UploadAsync(ms, overwrite: true);
+
+        await blobClient.SetMetadataAsync(new Dictionary<string, string>
+        {
+            ["subreddit"] = export.Subreddit,
+            ["threadCount"] = export.ThreadCount.ToString(),
+            ["commentCount"] = export.CommentCount.ToString(),
+            ["limitReached"] = export.ThreadLimitReached.ToString(),
+            ["startDate"] = export.StartDate.ToString("o"),
+            ["endDate"] = export.EndDate.ToString("o"),
+            ["generatedAt"] = export.GeneratedAt.ToString("o")
+        });
+
+        _logger.LogInformation("Stored Reddit export {ExportId} for r/{Subreddit}", export.Id, export.Subreddit);
+    }
+
+    private static RedditExportListItem ToListItem(RedditSubredditExport export) => new()
+    {
+        Id = export.Id,
+        Subreddit = export.Subreddit,
+        StartDate = export.StartDate,
+        EndDate = export.EndDate,
+        GeneratedAt = export.GeneratedAt,
+        ThreadCount = export.ThreadCount,
+        CommentCount = export.CommentCount,
+        ThreadLimitReached = export.ThreadLimitReached
+    };
+
+    private static int CountComments(List<RedditCommentModel> comments)
+    {
+        var count = 0;
+        foreach (var comment in comments)
+        {
+            count++;
+            if (comment.Replies is { Count: > 0 })
+            {
+                count += CountComments(comment.Replies);
+            }
+        }
+        return count;
+    }
+
+    private static bool TryGetId(HttpRequestData req, out Guid id)
+    {
+        id = Guid.Empty;
+        var query = QueryHelpers.ParseQuery(req.Url.Query);
+        if (!query.TryGetValue("id", out var idValues))
+        {
+            return false;
+        }
+
+        return Guid.TryParse(idValues.ToString(), out id);
+    }
+
+    private static async Task<HttpResponseData> BadRequest(HttpRequestData req, string message)
+    {
+        var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+        await bad.WriteStringAsync(message);
+        return bad;
+    }
+
+    private async Task<HttpResponseData?> EnsureAdminAsync(HttpRequestData req)
+    {
+        var authenticatedUser = await _authMiddleware.GetUserAsync(req);
+        if (authenticatedUser is null)
+        {
+            var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+            await unauthorized.WriteStringAsync("Authentication required");
+            return unauthorized;
+        }
+
+        var userAccount = await _userAccountService.GetUserAccountAsync(authenticatedUser.UserId);
+        if (userAccount?.Tier != AccountTier.Admin)
+        {
+            var forbidden = req.CreateResponse(HttpStatusCode.Forbidden);
+            await forbidden.WriteStringAsync("Admin access required");
+            return forbidden;
+        }
+
+        return null;
+    }
+}

--- a/feedbackfunctions/Services/Reports/IReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/IReportStorageService.cs
@@ -13,6 +13,8 @@ public interface IReportStorageService
 
     BlobContainerClient RedditReportDataContainer { get; }
 
+    BlobContainerClient RedditExportsContainer { get; }
+
     TableClient ReportRequestsTable { get; }
 
     TableClient UserReportRequestsTable { get; }

--- a/feedbackfunctions/Services/Reports/ReportStorageService.cs
+++ b/feedbackfunctions/Services/Reports/ReportStorageService.cs
@@ -26,6 +26,8 @@ public class ReportStorageService : IReportStorageService
 
     public BlobContainerClient RedditReportDataContainer => _storage.RedditReportDataContainer;
 
+    public BlobContainerClient RedditExportsContainer => _storage.RedditExportsContainer;
+
     public TableClient ReportRequestsTable => _storage.ReportRequestsTable;
 
     public TableClient UserReportRequestsTable => _storage.UserReportRequestsTable;

--- a/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
+++ b/feedbackfunctions/Services/Storage/FeedbackStorageClients.cs
@@ -16,6 +16,7 @@ public class FeedbackStorageClients
             blobServiceClient.GetBlobContainerClient(StorageNames.WeeklySummariesContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.SharedAnalysesContainer),
             blobServiceClient.GetBlobContainerClient(StorageNames.RedditReportDataContainer),
+            blobServiceClient.GetBlobContainerClient(StorageNames.RedditExportsContainer),
             tableServiceClient.GetTableClient(StorageNames.UserAccountsTable),
             tableServiceClient.GetTableClient(StorageNames.UsageRecordsTable),
             tableServiceClient.GetTableClient(StorageNames.ApiKeysTable),
@@ -35,6 +36,7 @@ public class FeedbackStorageClients
         BlobContainerClient weeklySummariesContainer,
         BlobContainerClient sharedAnalysesContainer,
         BlobContainerClient redditReportDataContainer,
+        BlobContainerClient redditExportsContainer,
         TableClient userAccountsTable,
         TableClient usageRecordsTable,
         TableClient apiKeysTable,
@@ -51,6 +53,7 @@ public class FeedbackStorageClients
         WeeklySummariesContainer = weeklySummariesContainer;
         SharedAnalysesContainer = sharedAnalysesContainer;
         RedditReportDataContainer = redditReportDataContainer;
+        RedditExportsContainer = redditExportsContainer;
         UserAccountsTable = userAccountsTable;
         UsageRecordsTable = usageRecordsTable;
         ApiKeysTable = apiKeysTable;
@@ -74,6 +77,8 @@ public class FeedbackStorageClients
     public BlobContainerClient SharedAnalysesContainer { get; }
 
     public BlobContainerClient RedditReportDataContainer { get; }
+
+    public BlobContainerClient RedditExportsContainer { get; }
 
     public TableClient UserAccountsTable { get; }
 

--- a/feedbackfunctions/Services/Storage/StorageNames.cs
+++ b/feedbackfunctions/Services/Storage/StorageNames.cs
@@ -7,6 +7,7 @@ public static class StorageNames
     public const string WeeklySummariesContainer = "weekly-summaries";
     public const string SharedAnalysesContainer = "shared-analyses";
     public const string RedditReportDataContainer = "reddit-report-data";
+    public const string RedditExportsContainer = "reddit-exports";
 
     public const string UserAccountsTable = "UserAccounts";
     public const string UsageRecordsTable = "UsageRecords";

--- a/feedbackfunctions/Services/Storage/TableInitializationService.cs
+++ b/feedbackfunctions/Services/Storage/TableInitializationService.cs
@@ -40,7 +40,8 @@ public class TableInitializationService : ITableInitializationService
                 _storage.ReportsContainer.CreateIfNotExistsAsync(),
                 _storage.ReportsSummaryContainer.CreateIfNotExistsAsync(),
                 _storage.WeeklySummariesContainer.CreateIfNotExistsAsync(),
-                _storage.RedditReportDataContainer.CreateIfNotExistsAsync());
+                _storage.RedditReportDataContainer.CreateIfNotExistsAsync(),
+                _storage.RedditExportsContainer.CreateIfNotExistsAsync());
         });
 
     public Task EnsureAdminReportConfigsAsync() =>

--- a/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
+++ b/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
@@ -43,6 +43,13 @@
                     <div class="desc">Browse & download</div>
                 </a>
             </div>
+            <div class="col-6 col-md-3">
+                <a href="/admin/reddit-export" class="admin-feature-tile d-block text-decoration-none">
+                    <div class="icon-wrapper"><i class="bi bi-reddit"></i></div>
+                    <div class="title">Reddit Export</div>
+                    <div class="desc">Threads & comments</div>
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
@@ -67,8 +67,8 @@
                 New Export
             </div>
             <div class="card-body">
-                <div class="row g-3 align-items-end">
-                    <div class="col-12 col-md-4">
+                <div class="row g-3">
+                    <div class="col-12 col-lg-6">
                         <label class="form-label">Subreddit <span class="text-danger">*</span></label>
                         <div class="input-group">
                             <span class="input-group-text">r/</span>
@@ -76,17 +76,60 @@
                         </div>
                         <div class="form-text">Enter the subreddit name without the "r/" prefix</div>
                     </div>
-                    <div class="col-6 col-md-3">
-                        <label class="form-label">Start (UTC) <span class="text-danger">*</span></label>
-                        <input type="datetime-local" class="form-control" @bind="startDate" disabled="@isGenerating" />
+                    <div class="col-12 col-lg-6">
+                        <label class="form-label">Time zone</label>
+                        <select class="form-select" @bind="selectedTimeZoneId" disabled="@isGenerating">
+                            @foreach (var tz in timeZones)
+                            {
+                                <option value="@tz.Id">@tz.DisplayName</option>
+                            }
+                        </select>
+                        <div class="form-text">Start and end times are interpreted in this time zone</div>
                     </div>
-                    <div class="col-6 col-md-3">
-                        <label class="form-label">End (UTC) <span class="text-danger">*</span></label>
-                        <input type="datetime-local" class="form-control" @bind="endDate" disabled="@isGenerating" />
+                </div>
+
+                <div class="quick-ranges mt-3">
+                    <span class="form-label mb-0 me-2">Quick range</span>
+                    <div class="btn-group btn-group-sm flex-wrap" role="group" aria-label="Quick date ranges">
+                        @foreach (var preset in QuickRanges)
+                        {
+                            var isActive = activeQuickRangeHours == preset.Hours;
+                            <button type="button"
+                                    class="btn @(isActive ? "btn-primary" : "btn-outline-primary")"
+                                    disabled="@isGenerating"
+                                    @onclick="() => ApplyQuickRange(preset.Hours)">
+                                @preset.Label
+                            </button>
+                        }
                     </div>
-                    <div class="col-6 col-md-2">
+                </div>
+
+                <div class="row g-3 align-items-end mt-1">
+                    <div class="col-12 col-sm-6 col-lg-4">
+                        <label class="form-label">Start <span class="text-danger">*</span></label>
+                        <input type="datetime-local" class="form-control" @bind="startDate" @bind:after="OnRangeEdited" disabled="@isGenerating" />
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-4">
+                        <label class="form-label">End <span class="text-danger">*</span></label>
+                        <input type="datetime-local" class="form-control" @bind="endDate" @bind:after="OnRangeEdited" disabled="@isGenerating" />
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
                         <label class="form-label">Max threads</label>
                         <input type="number" class="form-control" @bind="maxThreads" min="1" max="500" disabled="@isGenerating" />
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <button class="btn btn-primary w-100" @onclick="GenerateExport" disabled="@isGenerating">
+                            @if (isGenerating)
+                            {
+                                <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                                <span>Generating…</span>
+                            }
+                            else
+                            {
+                                <i class="bi bi-download me-2"></i>
+                                <span>Generate</span>
+                            }
+                        </button>
                     </div>
                 </div>
 
@@ -98,24 +141,13 @@
                     </div>
                 }
 
-                <div class="mt-3 d-flex align-items-center gap-2">
-                    <button class="btn btn-primary" @onclick="GenerateExport" disabled="@isGenerating">
-                        @if (isGenerating)
-                        {
-                            <span class="spinner-border spinner-border-sm me-2" role="status"></span>
-                            <span>Generating…</span>
-                        }
-                        else
-                        {
-                            <i class="bi bi-download me-2"></i>
-                            <span>Generate Export</span>
-                        }
-                    </button>
-                    @if (isGenerating)
-                    {
-                        <span class="text-muted small">Fetching threads &amp; comments — this can take a little while.</span>
-                    }
-                </div>
+                @if (isGenerating)
+                {
+                    <div class="text-muted small mt-2">
+                        <i class="bi bi-hourglass-split me-1"></i>
+                        Fetching threads &amp; comments — this can take a little while.
+                    </div>
+                }
             </div>
         </div>
 
@@ -146,7 +178,7 @@
                             <thead>
                                 <tr>
                                     <th scope="col">Subreddit</th>
-                                    <th scope="col" class="d-none d-md-table-cell">Range (UTC)</th>
+                                    <th scope="col" class="d-none d-md-table-cell">Range</th>
                                     <th scope="col" class="d-none d-lg-table-cell">Generated</th>
                                     <th scope="col" class="text-center d-none d-sm-table-cell">Threads</th>
                                     <th scope="col" class="text-center d-none d-sm-table-cell">Comments</th>
@@ -166,7 +198,7 @@
                                         <td class="d-none d-md-table-cell">
                                             <span class="item-date">
                                                 <i class="bi bi-calendar-range me-1"></i>
-                                                @export.StartDate.UtcDateTime.ToString("MMM d, HH:mm") &ndash; @export.EndDate.UtcDateTime.ToString("MMM d, HH:mm")
+                                                @FormatInZone(export.StartDate) &ndash; @FormatInZone(export.EndDate)
                                             </span>
                                         </td>
                                         <td class="d-none d-lg-table-cell">
@@ -236,13 +268,42 @@
     private string validationMessage = string.Empty;
 
     private string subreddit = string.Empty;
-    private DateTime startDate = DateTime.UtcNow.AddDays(-7);
-    private DateTime endDate = DateTime.UtcNow;
+    private DateTime startDate;
+    private DateTime endDate;
     private int maxThreads = 200;
+
+    private IReadOnlyList<TimeZoneInfo> timeZones = Array.Empty<TimeZoneInfo>();
+    private string selectedTimeZoneId = TimeZoneInfo.Utc.Id;
+    private int? activeQuickRangeHours = 168;
+
+    private record QuickRangePreset(string Label, int Hours);
+
+    private static readonly QuickRangePreset[] QuickRanges =
+    {
+        new("Last 24 hours", 24),
+        new("Last 48 hours", 48),
+        new("Last 3 days", 72),
+        new("Last 7 days", 168)
+    };
 
     private List<RedditExportListItem> exports = new();
     private Guid? downloadingId = null;
     private Guid? deletingId = null;
+
+    private TimeZoneInfo SelectedTimeZone
+    {
+        get
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(selectedTimeZoneId);
+            }
+            catch
+            {
+                return TimeZoneInfo.Utc;
+            }
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -250,6 +311,10 @@
         {
             isLoading = true;
             errorMessage = string.Empty;
+
+            timeZones = TimeZoneInfo.GetSystemTimeZones();
+            selectedTimeZoneId = TimeZoneInfo.Local.Id;
+            ApplyQuickRange(168);
 
             var isAuthenticated = await AuthService.IsAuthenticatedAsync();
             if (!isAuthenticated)
@@ -278,6 +343,70 @@
         {
             isLoading = false;
         }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !isAdmin)
+        {
+            return;
+        }
+
+        try
+        {
+            var ianaId = await JSRuntime.InvokeAsync<string>("getBrowserTimeZone");
+            if (string.IsNullOrWhiteSpace(ianaId))
+            {
+                return;
+            }
+
+            string? resolvedId = null;
+            if (timeZones.Any(tz => tz.Id == ianaId))
+            {
+                resolvedId = ianaId;
+            }
+            else if (TimeZoneInfo.TryConvertIanaIdToWindowsId(ianaId, out var windowsId)
+                     && timeZones.Any(tz => tz.Id == windowsId))
+            {
+                resolvedId = windowsId;
+            }
+
+            if (resolvedId is not null && resolvedId != selectedTimeZoneId)
+            {
+                selectedTimeZoneId = resolvedId;
+                if (activeQuickRangeHours is int hours)
+                {
+                    ApplyQuickRange(hours);
+                }
+                StateHasChanged();
+            }
+        }
+        catch
+        {
+            // Time zone detection is best-effort; fall back to the server's local zone.
+        }
+    }
+
+    private void ApplyQuickRange(int hours)
+    {
+        activeQuickRangeHours = hours;
+        var nowInZone = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, SelectedTimeZone).DateTime;
+        // Trim to whole minutes so the datetime-local control shows clean values.
+        nowInZone = new DateTime(nowInZone.Year, nowInZone.Month, nowInZone.Day, nowInZone.Hour, nowInZone.Minute, 0);
+        endDate = nowInZone;
+        startDate = nowInZone.AddHours(-hours);
+    }
+
+    private void OnRangeEdited()
+    {
+        // Manual edits clear the active quick-range highlight.
+        activeQuickRangeHours = null;
+    }
+
+    private string FormatInZone(DateTimeOffset value)
+    {
+        var local = TimeZoneInfo.ConvertTime(value, SelectedTimeZone);
+        return local.ToString("MMM d, HH:mm");
     }
 
     private async Task LoadExports()
@@ -329,6 +458,13 @@
         return true;
     }
 
+    private DateTimeOffset ToUtcOffset(DateTime wallClock)
+    {
+        var unspecified = DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, SelectedTimeZone);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
     private async Task GenerateExport()
     {
         if (!Validate())
@@ -344,8 +480,8 @@
             var request = new CreateRedditExportRequest
             {
                 Subreddit = subreddit.Trim(),
-                StartDate = new DateTimeOffset(DateTime.SpecifyKind(startDate, DateTimeKind.Utc)),
-                EndDate = new DateTimeOffset(DateTime.SpecifyKind(endDate, DateTimeKind.Utc)),
+                StartDate = ToUtcOffset(startDate),
+                EndDate = ToUtcOffset(endDate),
                 MaxThreads = maxThreads
             };
 

--- a/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
@@ -1,0 +1,436 @@
+@page "/admin/reddit-export"
+@using FeedbackWebApp.Services
+@using FeedbackWebApp.Services.Authentication
+@using FeedbackWebApp.Services.Account
+@using SharedDump.Models.Reports
+@using SharedDump.Models.Account
+@using Microsoft.JSInterop
+@inject FeedbackWebApp.Services.IRedditExportService RedditExportService
+@inject IAuthenticationService AuthService
+@inject IAccountServiceProvider AccountServiceProvider
+@inject IToastService ToastService
+@inject IJSRuntime JSRuntime
+@inject NavigationManager Navigation
+
+@using FeedbackWebApp.Components.Admin
+@namespace FeedbackWebApp.Components.Pages.Admin
+
+<PageTitle>Reddit Export - FeedbackFlow</PageTitle>
+
+<div class="container my-4">
+    <div class="mb-3">
+        <a href="/admin" class="btn btn-outline-secondary btn-sm">
+            <i class="bi bi-arrow-left me-1"></i> Back to Admin Home
+        </a>
+    </div>
+
+    @if (isLoading)
+    {
+        <AdminLoadingSpinner LoadingTitle="Reddit Export"
+                           LoadingMessage="Loading the subreddit export portal..."
+                           SpinnerIcon="bi-reddit" />
+    }
+    else if (!isAdmin)
+    {
+        <div class="alert alert-danger" role="alert">
+            <i class="bi bi-shield-exclamation me-2"></i>
+            <strong>Access Denied:</strong> This page is only available to administrators.
+        </div>
+    }
+    else
+    {
+        <div class="d-flex justify-content-between align-items-center mb-4 admin-header">
+            <div>
+                <h1 class="feedbackflow-title mb-2">
+                    <i class="bi bi-reddit me-2"></i>
+                    Reddit Export
+                </h1>
+                <p class="text-muted mb-0">Export all threads and comments for a subreddit over a date range (max 7 days)</p>
+            </div>
+            <button class="btn btn-outline-primary" @onclick="LoadExports" disabled="@(isRefreshing || isGenerating)">
+                <i class="bi bi-arrow-clockwise me-2"></i>
+                Refresh
+            </button>
+        </div>
+
+        @if (!string.IsNullOrEmpty(errorMessage))
+        {
+            <div class="alert alert-danger" role="alert">
+                <i class="bi bi-exclamation-triangle me-2"></i>
+                @errorMessage
+            </div>
+        }
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="bi bi-plus-circle me-1"></i>
+                New Export
+            </div>
+            <div class="card-body">
+                <div class="row g-3 align-items-end">
+                    <div class="col-12 col-md-4">
+                        <label class="form-label">Subreddit <span class="text-danger">*</span></label>
+                        <div class="input-group">
+                            <span class="input-group-text">r/</span>
+                            <input type="text" class="form-control" @bind="subreddit" placeholder="e.g., dotnet" disabled="@isGenerating" />
+                        </div>
+                        <div class="form-text">Enter the subreddit name without the "r/" prefix</div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label">Start (UTC) <span class="text-danger">*</span></label>
+                        <input type="datetime-local" class="form-control" @bind="startDate" disabled="@isGenerating" />
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label class="form-label">End (UTC) <span class="text-danger">*</span></label>
+                        <input type="datetime-local" class="form-control" @bind="endDate" disabled="@isGenerating" />
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <label class="form-label">Max threads</label>
+                        <input type="number" class="form-control" @bind="maxThreads" min="1" max="500" disabled="@isGenerating" />
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrEmpty(validationMessage))
+                {
+                    <div class="alert alert-warning mt-3 mb-0" role="alert">
+                        <i class="bi bi-exclamation-triangle me-2"></i>
+                        @validationMessage
+                    </div>
+                }
+
+                <div class="mt-3 d-flex align-items-center gap-2">
+                    <button class="btn btn-primary" @onclick="GenerateExport" disabled="@isGenerating">
+                        @if (isGenerating)
+                        {
+                            <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                            <span>Generating…</span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-download me-2"></i>
+                            <span>Generate Export</span>
+                        }
+                    </button>
+                    @if (isGenerating)
+                    {
+                        <span class="text-muted small">Fetching threads &amp; comments — this can take a little while.</span>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <i class="bi bi-clock-history me-1"></i>
+                Export History
+            </div>
+            <div class="card-body">
+                @if (isRefreshing)
+                {
+                    <div class="text-center py-3">
+                        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                        Loading exports…
+                    </div>
+                }
+                else if (exports.Count == 0)
+                {
+                    <div class="alert alert-info mb-0" role="alert">
+                        <i class="bi bi-info-circle me-2"></i>
+                        No exports yet. Create your first export above.
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle admin-reddit-export-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Subreddit</th>
+                                    <th scope="col" class="d-none d-md-table-cell">Range (UTC)</th>
+                                    <th scope="col" class="d-none d-lg-table-cell">Generated</th>
+                                    <th scope="col" class="text-center d-none d-sm-table-cell">Threads</th>
+                                    <th scope="col" class="text-center d-none d-sm-table-cell">Comments</th>
+                                    <th scope="col" class="text-center">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var export in exports)
+                                {
+                                    <tr @key="export.Id">
+                                        <td>
+                                            <div class="item-name">
+                                                <i class="bi bi-reddit me-1"></i>
+                                                r/@export.Subreddit
+                                            </div>
+                                        </td>
+                                        <td class="d-none d-md-table-cell">
+                                            <span class="item-date">
+                                                <i class="bi bi-calendar-range me-1"></i>
+                                                @export.StartDate.UtcDateTime.ToString("MMM d, HH:mm") &ndash; @export.EndDate.UtcDateTime.ToString("MMM d, HH:mm")
+                                            </span>
+                                        </td>
+                                        <td class="d-none d-lg-table-cell">
+                                            <span class="item-date">
+                                                <i class="bi bi-clock me-1"></i>
+                                                @export.GeneratedAt.ToLocalTime().ToString("g")
+                                            </span>
+                                        </td>
+                                        <td class="text-center d-none d-sm-table-cell">
+                                            @export.ThreadCount
+                                            @if (export.ThreadLimitReached)
+                                            {
+                                                <i class="bi bi-exclamation-circle text-warning ms-1" title="Thread cap was reached; more threads may exist in this window."></i>
+                                            }
+                                        </td>
+                                        <td class="text-center d-none d-sm-table-cell">@export.CommentCount</td>
+                                        <td class="text-center">
+                                            <div class="action-buttons">
+                                                <button class="btn btn-sm btn-outline-primary"
+                                                        title="Download JSON"
+                                                        disabled="@(downloadingId == export.Id)"
+                                                        @onclick="() => DownloadExport(export)">
+                                                    @if (downloadingId == export.Id)
+                                                    {
+                                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <i class="bi bi-download"></i>
+                                                    }
+                                                    <span class="ms-1 d-none d-md-inline">Download</span>
+                                                </button>
+                                                <button class="btn btn-sm btn-outline-danger"
+                                                        title="Delete export"
+                                                        disabled="@(deletingId == export.Id)"
+                                                        @onclick="() => DeleteExport(export)">
+                                                    @if (deletingId == export.Id)
+                                                    {
+                                                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <i class="bi bi-trash"></i>
+                                                    }
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private const int MaxWindowDays = 7;
+
+    private bool isLoading = true;
+    private bool isAdmin = false;
+    private bool isRefreshing = false;
+    private bool isGenerating = false;
+    private string errorMessage = string.Empty;
+    private string validationMessage = string.Empty;
+
+    private string subreddit = string.Empty;
+    private DateTime startDate = DateTime.UtcNow.AddDays(-7);
+    private DateTime endDate = DateTime.UtcNow;
+    private int maxThreads = 200;
+
+    private List<RedditExportListItem> exports = new();
+    private Guid? downloadingId = null;
+    private Guid? deletingId = null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            isLoading = true;
+            errorMessage = string.Empty;
+
+            var isAuthenticated = await AuthService.IsAuthenticatedAsync();
+            if (!isAuthenticated)
+            {
+                Navigation.NavigateTo("/");
+                return;
+            }
+
+            var accountService = AccountServiceProvider.GetService();
+            var accountResult = await accountService.GetUserAccountAndLimitsAsync();
+            if (accountResult.HasValue)
+            {
+                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+            }
+
+            if (isAdmin)
+            {
+                await LoadExports();
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error loading export portal: {ex.Message}";
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task LoadExports()
+    {
+        try
+        {
+            isRefreshing = true;
+            errorMessage = string.Empty;
+            exports = await RedditExportService.GetExportsAsync();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error loading exports: {ex.Message}";
+        }
+        finally
+        {
+            isRefreshing = false;
+        }
+    }
+
+    private bool Validate()
+    {
+        validationMessage = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(subreddit))
+        {
+            validationMessage = "A subreddit is required.";
+            return false;
+        }
+
+        if (endDate <= startDate)
+        {
+            validationMessage = "The end date must be after the start date.";
+            return false;
+        }
+
+        if ((endDate - startDate).TotalDays > MaxWindowDays)
+        {
+            validationMessage = $"The date range cannot exceed {MaxWindowDays} days.";
+            return false;
+        }
+
+        if (maxThreads < 1 || maxThreads > 500)
+        {
+            validationMessage = "Max threads must be between 1 and 500.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private async Task GenerateExport()
+    {
+        if (!Validate())
+        {
+            return;
+        }
+
+        try
+        {
+            isGenerating = true;
+            errorMessage = string.Empty;
+
+            var request = new CreateRedditExportRequest
+            {
+                Subreddit = subreddit.Trim(),
+                StartDate = new DateTimeOffset(DateTime.SpecifyKind(startDate, DateTimeKind.Utc)),
+                EndDate = new DateTimeOffset(DateTime.SpecifyKind(endDate, DateTimeKind.Utc)),
+                MaxThreads = maxThreads
+            };
+
+            var created = await RedditExportService.CreateExportAsync(request);
+            exports.Insert(0, created);
+
+            if (created.ThreadCount == 0)
+            {
+                await ToastService.ShowWarningAsync("No threads were found in that window.");
+            }
+            else
+            {
+                await ToastService.ShowSuccessAsync(
+                    $"Export created: {created.ThreadCount} threads, {created.CommentCount} comments.");
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to create export: {ex.Message}";
+            await ToastService.ShowErrorAsync(errorMessage);
+        }
+        finally
+        {
+            isGenerating = false;
+        }
+    }
+
+    private async Task DownloadExport(RedditExportListItem export)
+    {
+        try
+        {
+            downloadingId = export.Id;
+            var json = await RedditExportService.DownloadExportAsync(export.Id);
+            if (string.IsNullOrEmpty(json))
+            {
+                await ToastService.ShowErrorAsync("No data available for this export.");
+                return;
+            }
+
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
+            var dataUrl = $"data:application/json;base64,{base64}";
+            var fileName = $"reddit-export-{export.Subreddit}-{export.Id}.json";
+
+            await JSRuntime.InvokeAsync<bool>("downloadFile", dataUrl, fileName);
+        }
+        catch (Exception ex)
+        {
+            await ToastService.ShowErrorAsync($"Failed to download export: {ex.Message}");
+        }
+        finally
+        {
+            downloadingId = null;
+        }
+    }
+
+    private async Task DeleteExport(RedditExportListItem export)
+    {
+        try
+        {
+            var confirmed = await JSRuntime.InvokeAsync<bool>("confirm",
+                $"Delete the export for r/{export.Subreddit}? This cannot be undone.");
+            if (!confirmed)
+            {
+                return;
+            }
+
+            deletingId = export.Id;
+            var success = await RedditExportService.DeleteExportAsync(export.Id);
+            if (success)
+            {
+                exports.Remove(export);
+                await ToastService.ShowSuccessAsync("Export deleted.");
+            }
+            else
+            {
+                await ToastService.ShowErrorAsync("Export not found.");
+            }
+        }
+        catch (Exception ex)
+        {
+            await ToastService.ShowErrorAsync($"Failed to delete export: {ex.Message}");
+        }
+        finally
+        {
+            deletingId = null;
+        }
+    }
+}

--- a/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor.css
+++ b/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor.css
@@ -65,6 +65,22 @@
     gap: 0.5rem;
 }
 
+/* Quick-range presets */
+.quick-ranges {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.quick-ranges .btn-group {
+    gap: 0.4rem;
+}
+
+.quick-ranges .btn-group .btn {
+    border-radius: var(--border-radius) !important;
+}
+
 /* The new-export card header uses the app's primary gradient for a clear accent */
 .card-header {
     color: var(--text-primary);

--- a/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor.css
+++ b/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor.css
@@ -1,0 +1,79 @@
+.admin-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.admin-reddit-export-table {
+    width: 100%;
+    margin-bottom: 0;
+    /* Override Bootstrap's table CSS variables so cells follow the app theme
+       instead of defaulting to a white background in dark mode. */
+    --bs-table-bg: transparent;
+    --bs-table-color: var(--text-primary);
+    background: var(--card-bg);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.admin-reddit-export-table th {
+    background: rgba(var(--bg-secondary-rgb), 0.8);
+    color: var(--text-primary);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    letter-spacing: 0.5px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.admin-reddit-export-table td {
+    background: var(--card-bg);
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-color);
+    transition: background-color 0.3s ease;
+}
+
+.admin-reddit-export-table tbody tr:hover td {
+    background: linear-gradient(135deg, rgba(var(--primary-color-rgb), 0.05) 0%, rgba(var(--primary-color-rgb), 0.1) 100%);
+}
+
+.admin-reddit-export-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.item-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+}
+
+.item-name .bi-reddit {
+    color: #ff4500;
+}
+
+.item-date {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    display: inline-flex;
+    align-items: center;
+}
+
+.action-buttons {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+/* The new-export card header uses the app's primary gradient for a clear accent */
+.card-header {
+    color: var(--text-primary);
+}
+
+/* Responsive adjustments */
+@media (max-width: 767.98px) {
+    .admin-reddit-export-table th,
+    .admin-reddit-export-table td {
+        font-size: 0.85rem;
+    }
+}

--- a/feedbackwebapp/Program.cs
+++ b/feedbackwebapp/Program.cs
@@ -114,6 +114,24 @@ builder.Services.AddScoped<FeedbackWebApp.Services.IReportDataAdminService>(serv
     }
 });
 
+// Register Admin Reddit Export Service
+builder.Services.AddScoped<FeedbackWebApp.Services.IRedditExportService>(serviceProvider =>
+{
+    if (useMocks)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<FeedbackWebApp.Services.Mock.MockRedditExportService>>();
+        return new FeedbackWebApp.Services.Mock.MockRedditExportService(logger);
+    }
+    else
+    {
+        var httpClient = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient("DefaultClient");
+        var headerService = serviceProvider.GetRequiredService<IAuthenticationHeaderService>();
+        var logger = serviceProvider.GetRequiredService<ILogger<RedditExportService>>();
+        var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        return new RedditExportService(httpClient, headerService, logger, configuration);
+    }
+});
+
 // Register Admin Dashboard Service
 builder.Services.AddScoped<IAdminDashboardService>(serviceProvider =>
 {

--- a/feedbackwebapp/Services/IRedditExportService.cs
+++ b/feedbackwebapp/Services/IRedditExportService.cs
@@ -1,0 +1,31 @@
+using SharedDump.Models.Reports;
+
+namespace FeedbackWebApp.Services;
+
+/// <summary>
+/// Web application service for the admin Reddit export portal. Creates on-demand subreddit
+/// exports (all threads + comments within a date range), lists stored exports, and downloads
+/// or deletes them via the Azure Functions backend.
+/// </summary>
+public interface IRedditExportService
+{
+    /// <summary>
+    /// Creates a new subreddit export for the given window and returns its metadata.
+    /// </summary>
+    Task<RedditExportListItem> CreateExportAsync(CreateRedditExportRequest request);
+
+    /// <summary>
+    /// Gets metadata for all stored subreddit exports, newest first.
+    /// </summary>
+    Task<List<RedditExportListItem>> GetExportsAsync();
+
+    /// <summary>
+    /// Downloads the full JSON for a stored export. Returns null when not found.
+    /// </summary>
+    Task<string?> DownloadExportAsync(Guid exportId);
+
+    /// <summary>
+    /// Deletes a stored export. Returns true when an export was deleted.
+    /// </summary>
+    Task<bool> DeleteExportAsync(Guid exportId);
+}

--- a/feedbackwebapp/Services/Mock/MockRedditExportService.cs
+++ b/feedbackwebapp/Services/Mock/MockRedditExportService.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using SharedDump.Models.Reddit;
+using SharedDump.Models.Reports;
+
+namespace FeedbackWebApp.Services.Mock;
+
+/// <summary>
+/// Mock implementation of <see cref="IRedditExportService"/> for local development and tests.
+/// </summary>
+public class MockRedditExportService : IRedditExportService
+{
+    private readonly ILogger<MockRedditExportService> _logger;
+
+    private readonly List<RedditExportListItem> _exports = new()
+    {
+        new RedditExportListItem
+        {
+            Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Subreddit = "dotnet",
+            StartDate = DateTimeOffset.UtcNow.AddDays(-7),
+            EndDate = DateTimeOffset.UtcNow,
+            GeneratedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            ThreadCount = 42,
+            CommentCount = 1380,
+            ThreadLimitReached = false
+        },
+        new RedditExportListItem
+        {
+            Id = Guid.Parse("44444444-4444-4444-4444-444444444444"),
+            Subreddit = "csharp",
+            StartDate = DateTimeOffset.UtcNow.AddDays(-5),
+            EndDate = DateTimeOffset.UtcNow.AddDays(-2),
+            GeneratedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            ThreadCount = 200,
+            CommentCount = 9123,
+            ThreadLimitReached = true
+        }
+    };
+
+    public MockRedditExportService(ILogger<MockRedditExportService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<RedditExportListItem> CreateExportAsync(CreateRedditExportRequest request)
+    {
+        await Task.Delay(800);
+        var item = new RedditExportListItem
+        {
+            Id = Guid.NewGuid(),
+            Subreddit = request.Subreddit,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            ThreadCount = 12,
+            CommentCount = 256,
+            ThreadLimitReached = false
+        };
+        _exports.Insert(0, item);
+        _logger.LogInformation("Mock: Created export for r/{Subreddit}", request.Subreddit);
+        return item;
+    }
+
+    public async Task<List<RedditExportListItem>> GetExportsAsync()
+    {
+        await Task.Delay(200);
+        _logger.LogInformation("Mock: Returning {Count} sample exports", _exports.Count);
+        return _exports.OrderByDescending(e => e.GeneratedAt).ToList();
+    }
+
+    public async Task<string?> DownloadExportAsync(Guid exportId)
+    {
+        await Task.Delay(200);
+        var item = _exports.FirstOrDefault(e => e.Id == exportId);
+        if (item is null)
+        {
+            _logger.LogInformation("Mock: No export found for {ExportId}", exportId);
+            return null;
+        }
+
+        var export = new RedditSubredditExport
+        {
+            Id = item.Id,
+            Subreddit = item.Subreddit,
+            StartDate = item.StartDate,
+            EndDate = item.EndDate,
+            GeneratedAt = item.GeneratedAt,
+            ThreadCount = item.ThreadCount,
+            CommentCount = item.CommentCount,
+            ThreadLimitReached = item.ThreadLimitReached,
+            SubredditInfo = new RedditSubredditInfo
+            {
+                DisplayName = item.Subreddit,
+                Title = $"r/{item.Subreddit}",
+                PublicDescription = $"Mock export for r/{item.Subreddit}"
+            }
+        };
+
+        return JsonSerializer.Serialize(export, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public async Task<bool> DeleteExportAsync(Guid exportId)
+    {
+        await Task.Delay(150);
+        var item = _exports.FirstOrDefault(e => e.Id == exportId);
+        if (item is null)
+        {
+            return false;
+        }
+        _exports.Remove(item);
+        _logger.LogInformation("Mock: Deleted export {ExportId}", exportId);
+        return true;
+    }
+}

--- a/feedbackwebapp/Services/RedditExportService.cs
+++ b/feedbackwebapp/Services/RedditExportService.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using SharedDump.Models.Reports;
+using FeedbackWebApp.Services.Authentication;
+
+namespace FeedbackWebApp.Services;
+
+/// <summary>
+/// Communicates with the Azure Functions backend to create, list, download, and delete
+/// on-demand Reddit subreddit exports for the admin export portal.
+///
+/// API Endpoints:
+/// - POST   /api/CreateRedditExport            - Create a new export
+/// - GET    /api/GetRedditExports              - List all stored exports (metadata)
+/// - GET    /api/DownloadRedditExport?id={id}  - Download full JSON for an export
+/// - DELETE /api/DeleteRedditExport?id={id}    - Delete an export
+/// </summary>
+public class RedditExportService : IRedditExportService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IAuthenticationHeaderService _headerService;
+    private readonly ILogger<RedditExportService> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _baseUrl;
+    private readonly string _functionsKey;
+
+    public RedditExportService(
+        HttpClient httpClient,
+        IAuthenticationHeaderService headerService,
+        ILogger<RedditExportService> logger,
+        IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _headerService = headerService;
+        _logger = logger;
+        _baseUrl = configuration["FeedbackApi:BaseUrl"]
+            ?? throw new InvalidOperationException("FeedbackApi:BaseUrl not configured");
+        _functionsKey = configuration["FeedbackApi:FunctionsKey"]
+            ?? throw new InvalidOperationException("FeedbackApi:FunctionsKey not configured");
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public async Task<RedditExportListItem> CreateExportAsync(CreateRedditExportRequest request)
+    {
+        try
+        {
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post,
+                $"{_baseUrl}/api/CreateRedditExport?code={Uri.EscapeDataString(_functionsKey)}")
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(request, _jsonOptions), Encoding.UTF8, "application/json")
+            };
+            await _headerService.AddAuthenticationHeadersAsync(httpRequest);
+
+            var response = await _httpClient.SendAsync(httpRequest);
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = JsonSerializer.Deserialize<RedditExportListItem>(content, _jsonOptions);
+                return result ?? throw new InvalidOperationException("Empty response from export service.");
+            }
+
+            var message = response.StatusCode switch
+            {
+                HttpStatusCode.Unauthorized => "Authentication required",
+                HttpStatusCode.Forbidden => "Admin access required",
+                HttpStatusCode.BadRequest => string.IsNullOrWhiteSpace(content)
+                    ? "Invalid export request"
+                    : content,
+                _ => $"Server error ({response.StatusCode})"
+            };
+
+            _logger.LogError("Failed to create export. Status: {StatusCode}, Error: {Error}",
+                response.StatusCode, content);
+            throw new InvalidOperationException(message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating Reddit export");
+            throw;
+        }
+    }
+
+    public async Task<List<RedditExportListItem>> GetExportsAsync()
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_baseUrl}/api/GetRedditExports?code={Uri.EscapeDataString(_functionsKey)}");
+            await _headerService.AddAuthenticationHeadersAsync(request);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<RedditExportListResponse>(content, _jsonOptions);
+                return result?.Exports ?? new List<RedditExportListItem>();
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync();
+            var statusCodeMessage = response.StatusCode switch
+            {
+                HttpStatusCode.Unauthorized => "Authentication required",
+                HttpStatusCode.Forbidden => "Admin access required",
+                _ => $"Server error ({response.StatusCode})"
+            };
+
+            _logger.LogError("Failed to get exports. Status: {StatusCode}, Error: {Error}",
+                response.StatusCode, errorContent);
+            throw new InvalidOperationException($"Failed to get exports: {statusCodeMessage}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting Reddit exports");
+            throw;
+        }
+    }
+
+    public async Task<string?> DownloadExportAsync(Guid exportId)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{_baseUrl}/api/DownloadRedditExport?id={Uri.EscapeDataString(exportId.ToString())}&code={Uri.EscapeDataString(_functionsKey)}");
+            await _headerService.AddAuthenticationHeadersAsync(request);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync();
+            _logger.LogError("Failed to download export {ExportId}. Status: {StatusCode}, Error: {Error}",
+                exportId, response.StatusCode, errorContent);
+            throw new InvalidOperationException($"Failed to download export ({response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error downloading Reddit export {ExportId}", exportId);
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteExportAsync(Guid exportId)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{_baseUrl}/api/DeleteRedditExport?id={Uri.EscapeDataString(exportId.ToString())}&code={Uri.EscapeDataString(_functionsKey)}");
+            await _headerService.AddAuthenticationHeadersAsync(request);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return true;
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            var errorContent = await response.Content.ReadAsStringAsync();
+            _logger.LogError("Failed to delete export {ExportId}. Status: {StatusCode}, Error: {Error}",
+                exportId, response.StatusCode, errorContent);
+            throw new InvalidOperationException($"Failed to delete export ({response.StatusCode}).");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting Reddit export {ExportId}", exportId);
+            throw;
+        }
+    }
+}

--- a/feedbackwebapp/wwwroot/js/app.js
+++ b/feedbackwebapp/wwwroot/js/app.js
@@ -169,6 +169,18 @@ function downloadFile(dataUrl, fileName) {
 
 window.downloadFile = downloadFile;
 
+// Returns the browser's IANA time zone identifier (e.g., "America/Los_Angeles")
+function getBrowserTimeZone() {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+    } catch (error) {
+        console.error('Error resolving browser time zone:', error);
+        return '';
+    }
+}
+
+window.getBrowserTimeZone = getBrowserTimeZone;
+
 
 document.addEventListener('DOMContentLoaded', async () => {
     // Add the toast container to the DOM if it doesn't exist

--- a/shareddump/Models/Reddit/RedditApiModels.cs
+++ b/shareddump/Models/Reddit/RedditApiModels.cs
@@ -18,6 +18,9 @@ public class RedditListing
 public class RedditListingData
 {
     public RedditThingData[] Children { get; set; } = Array.Empty<RedditThingData>();
+
+    [JsonPropertyName("after")]
+    public string? After { get; set; }
 }
 
 public class RedditThingData

--- a/shareddump/Models/Reddit/RedditService.cs
+++ b/shareddump/Models/Reddit/RedditService.cs
@@ -204,6 +204,105 @@ public sealed class RedditService : IDisposable
         return threads;
     }
 
+    /// <summary>
+    /// Fetches basic info for all threads in a subreddit created within the given UTC window,
+    /// paginating the "new" listing until threads fall before <paramref name="startDate"/> or the
+    /// <paramref name="maxThreads"/> cap is reached.
+    /// </summary>
+    /// <param name="subreddit">The subreddit name (without the "r/" prefix)</param>
+    /// <param name="startDate">Start of the window (inclusive, UTC)</param>
+    /// <param name="endDate">End of the window (inclusive, UTC)</param>
+    /// <param name="maxThreads">Maximum number of threads to return</param>
+    /// <returns>The matching threads (basic info only) and whether the cap was hit</returns>
+    public async Task<(List<RedditThreadModel> Threads, bool LimitReached)> GetSubredditThreadsInDateRange(
+        string subreddit, DateTimeOffset startDate, DateTimeOffset endDate, int maxThreads = 200)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subreddit);
+
+        var collected = new List<RedditThreadModel>();
+        string? after = null;
+        var limitReached = false;
+        const int pageSize = 100;
+
+        // Reddit's "new" listing only reaches ~1000 items back; bound the loop accordingly.
+        for (var page = 0; page < 11; page++)
+        {
+            await EnsureValidTokenAsync();
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+
+            var url = $"https://oauth.reddit.com/r/{subreddit}/new?limit={pageSize}";
+            if (!string.IsNullOrEmpty(after))
+            {
+                url += $"&after={Uri.EscapeDataString(after)}";
+            }
+
+            var response = await _client.GetStringAsync(url);
+            var listing = JsonSerializer.Deserialize(response, RedditJsonContext.Default.RedditListing);
+            if (listing?.Data?.Children == null || listing.Data.Children.Length == 0)
+            {
+                break;
+            }
+
+            var reachedOlderThanStart = false;
+            foreach (var child in listing.Data.Children)
+            {
+                if (child.Data == null) continue;
+
+                var created = DateTimeOffset.FromUnixTimeSeconds((long)child.Data.CreatedUtc);
+
+                // "new" is newest-first; once we pass the start of the window we can stop.
+                if (created < startDate)
+                {
+                    reachedOlderThanStart = true;
+                    break;
+                }
+
+                if (created > endDate)
+                {
+                    // Newer than the window - skip but keep paging back.
+                    continue;
+                }
+
+                collected.Add(new RedditThreadModel
+                {
+                    Id = child.Data.Id,
+                    Title = child.Data.Title ?? "[No Title]",
+                    Author = child.Data.Author,
+                    SelfText = child.Data.Selftext ?? string.Empty,
+                    CreatedUtc = created,
+                    Score = child.Data.Score,
+                    NumComments = child.Data.NumComments,
+                    Url = child.Data.Permalink.StartsWith("http")
+                        ? child.Data.Permalink
+                        : $"https://www.reddit.com{child.Data.Permalink}",
+                    Permalink = child.Data.Permalink,
+                    Subreddit = subreddit,
+                    UpvoteRatio = 1.0,
+                    Comments = []
+                });
+
+                if (collected.Count >= maxThreads)
+                {
+                    limitReached = true;
+                    break;
+                }
+            }
+
+            if (reachedOlderThanStart || limitReached)
+            {
+                break;
+            }
+
+            after = listing.Data.After;
+            if (string.IsNullOrEmpty(after))
+            {
+                break;
+            }
+        }
+
+        return (collected, limitReached);
+    }
+
     public async Task<RedditSubredditInfo> GetSubredditInfo(string subreddit)
     {
         await EnsureValidTokenAsync();

--- a/shareddump/Models/Reports/RedditSubredditExport.cs
+++ b/shareddump/Models/Reports/RedditSubredditExport.cs
@@ -1,0 +1,112 @@
+using SharedDump.Models.Reddit;
+
+namespace SharedDump.Models.Reports;
+
+/// <summary>
+/// A complete, on-demand export of a subreddit's threads and comments captured for a
+/// specific date/time window. Stored as a single JSON blob (keyed by <see cref="Id"/>)
+/// in the admin Reddit export portal. Contains the fetched data only (threads, comments,
+/// subreddit info) - no AI analyses.
+/// </summary>
+public class RedditSubredditExport
+{
+    /// <summary>
+    /// Unique identifier for this export (also the blob name, without extension).
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// The subreddit the export was generated for (without the "r/" prefix).
+    /// </summary>
+    public string Subreddit { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Start of the capture window (inclusive, UTC).
+    /// </summary>
+    public DateTimeOffset StartDate { get; set; }
+
+    /// <summary>
+    /// End of the capture window (inclusive, UTC).
+    /// </summary>
+    public DateTimeOffset EndDate { get; set; }
+
+    /// <summary>
+    /// When this export was generated.
+    /// </summary>
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Number of threads captured in this export.
+    /// </summary>
+    public int ThreadCount { get; set; }
+
+    /// <summary>
+    /// Total number of comments captured across all threads.
+    /// </summary>
+    public int CommentCount { get; set; }
+
+    /// <summary>
+    /// Whether the export hit the configured maximum thread cap (i.e. the window may contain
+    /// more threads than were captured).
+    /// </summary>
+    public bool ThreadLimitReached { get; set; }
+
+    /// <summary>
+    /// Metadata about the subreddit at the time of capture.
+    /// </summary>
+    public RedditSubredditInfo? SubredditInfo { get; set; }
+
+    /// <summary>
+    /// The full threads (including nested comments) captured in the window.
+    /// </summary>
+    public List<RedditThreadModel> Threads { get; set; } = new();
+}
+
+/// <summary>
+/// Request payload to create a new Reddit subreddit export.
+/// </summary>
+public class CreateRedditExportRequest
+{
+    /// <summary>
+    /// Subreddit name (without the "r/" prefix).
+    /// </summary>
+    public string Subreddit { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Start of the capture window (inclusive, UTC).
+    /// </summary>
+    public DateTimeOffset StartDate { get; set; }
+
+    /// <summary>
+    /// End of the capture window (inclusive, UTC).
+    /// </summary>
+    public DateTimeOffset EndDate { get; set; }
+
+    /// <summary>
+    /// Maximum number of threads to capture (server clamps this to a safe range).
+    /// </summary>
+    public int MaxThreads { get; set; } = 200;
+}
+
+/// <summary>
+/// Lightweight metadata describing a stored Reddit export for the admin export portal.
+/// </summary>
+public class RedditExportListItem
+{
+    public Guid Id { get; set; }
+    public string Subreddit { get; set; } = string.Empty;
+    public DateTimeOffset StartDate { get; set; }
+    public DateTimeOffset EndDate { get; set; }
+    public DateTimeOffset GeneratedAt { get; set; }
+    public int ThreadCount { get; set; }
+    public int CommentCount { get; set; }
+    public bool ThreadLimitReached { get; set; }
+}
+
+/// <summary>
+/// Response payload for the admin Reddit export listing endpoint.
+/// </summary>
+public class RedditExportListResponse
+{
+    public List<RedditExportListItem> Exports { get; set; } = new();
+}

--- a/shareddump/Services/Interfaces/IRedditService.cs
+++ b/shareddump/Services/Interfaces/IRedditService.cs
@@ -7,6 +7,13 @@ public interface IRedditService
     // Original service methods for compatibility
     Task<RedditThreadModel> GetThreadWithComments(string threadId);
     Task<List<RedditThreadModel>> GetSubredditThreadsBasicInfo(string subreddit, string sortBy = "hot", DateTimeOffset? cutoffDate = null);
+
+    /// <summary>
+    /// Fetches basic info for all threads created within a UTC window, capped at <paramref name="maxThreads"/>.
+    /// Returns the threads and whether the cap was reached.
+    /// </summary>
+    Task<(List<RedditThreadModel> Threads, bool LimitReached)> GetSubredditThreadsInDateRange(
+        string subreddit, DateTimeOffset startDate, DateTimeOffset endDate, int maxThreads = 200);
     
     // New unified interface methods
     Task<RedditListing<RedditSubmission>> GetSubredditPostsAsync(string subreddit, string sort = "hot", int limit = 25);

--- a/shareddump/Services/Mock/MockRedditService.cs
+++ b/shareddump/Services/Mock/MockRedditService.cs
@@ -211,11 +211,41 @@ public class MockRedditService : IRedditService
         }).ToList();
     }
 
-    // New unified interface methods
+    public async Task<(List<RedditThreadModel> Threads, bool LimitReached)> GetSubredditThreadsInDateRange(
+        string subreddit, DateTimeOffset startDate, DateTimeOffset endDate, int maxThreads = 200)
+    {
+        await Task.Delay(200); // Simulate API delay
+
+        var threads = _mockSubmissions
+            .Where(s => s.Subreddit.Equals(subreddit, StringComparison.OrdinalIgnoreCase))
+            .Select(s => DateTimeOffset.FromUnixTimeSeconds(s.CreatedUtc) is var created && created >= startDate && created <= endDate
+                ? s : null)
+            .Where(s => s is not null)
+            .Select(s => s!)
+            .Take(maxThreads)
+            .Select(s => new RedditThreadModel
+            {
+                Id = s.Id,
+                Title = s.Title,
+                Author = s.Author,
+                SelfText = s.SelfText,
+                Url = s.Url,
+                Subreddit = subreddit,
+                Score = s.Score,
+                UpvoteRatio = s.UpvoteRatio,
+                NumComments = s.NumComments,
+                Comments = new List<RedditCommentModel>(),
+                CreatedUtc = DateTimeOffset.FromUnixTimeSeconds(s.CreatedUtc),
+                Permalink = s.Permalink
+            })
+            .ToList();
+
+        return (threads, false);
+    }
     public async Task<RedditListing<RedditSubmission>> GetSubredditPostsAsync(string subreddit, string sort = "hot", int limit = 25)
     {
         await Task.Delay(200); // Simulate API delay
-        
+
         var filteredPosts = _mockSubmissions
             .Where(s => s.Subreddit.Equals(subreddit, StringComparison.OrdinalIgnoreCase))
             .Take(limit)

--- a/shareddump/Services/RedditServiceAdapter.cs
+++ b/shareddump/Services/RedditServiceAdapter.cs
@@ -23,6 +23,12 @@ public class RedditServiceAdapter : IRedditService
         return await _redditService.GetSubredditThreadsBasicInfo(subreddit, sortBy, cutoffDate);
     }
 
+    public async Task<(List<RedditThreadModel> Threads, bool LimitReached)> GetSubredditThreadsInDateRange(
+        string subreddit, DateTimeOffset startDate, DateTimeOffset endDate, int maxThreads = 200)
+    {
+        return await _redditService.GetSubredditThreadsInDateRange(subreddit, startDate, endDate, maxThreads);
+    }
+
     // New unified interface methods
     public async Task<RedditListing<RedditSubmission>> GetSubredditPostsAsync(string subreddit, string sort = "hot", int limit = 25)
     {


### PR DESCRIPTION
## Why

Admins need a way to pull the raw underlying data for a subreddit (all threads and all comments) over a specific window, independent of the automated weekly reports. This adds a self-service portal to capture and download that data on demand.

## What

A new admin-only page at `/admin/reddit-export` lets an admin pick a subreddit and a date/time range (max 7 days), fetch every thread plus its full comment tree in that window, store the result as a JSON blob, and browse a history of past exports with re-download and delete.

Generation runs synchronously with a loading spinner and is bounded by a configurable max-thread cap (default 200, hard limit 500) so a busy subreddit can't blow past the function timeout. All limits are enforced server-side, never trusting the client.

## How it fits together

- **shareddump**: New models (`RedditSubredditExport`, `CreateRedditExportRequest`, `RedditExportListItem`/`RedditExportListResponse`) and a new `RedditService.GetSubredditThreadsInDateRange` that paginates the `new` listing within the window until it passes the start date or hits the cap. Surfaced on `IRedditService`, the adapter, and the mock. Added an `After` cursor field to `RedditListingData` to support paging.
- **feedbackfunctions**: New `reddit-exports` blob container wired through `StorageNames`, `FeedbackStorageClients`, `IReportStorageService`/`ReportStorageService`, and `TableInitializationService`. New admin-gated `RedditExportFunctions` with Create/Get/Download/Delete endpoints. Create validates the 7-day window, clamps the thread cap, validates the subreddit, fetches comments with bounded concurrency, and stores the blob plus lightweight metadata (so the history list renders without downloading full blobs).
- **feedbackwebapp**: `IRedditExportService` with real and mock implementations registered conditionally on `useMocks`, the `AdminRedditExport` page (with scoped, theme-aware CSS) for the form, validation, generate spinner, and history table, and a new tile on the admin panel. Download reuses the existing `downloadFile` JS interop.

## Notes for reviewers

- `RedditService.GetThreadWithComments` hardcodes `Subreddit = "dotnet"` and doesn't always set the created date; the export overwrites each thread's subreddit with the requested one and backfills the created date from the listing so stored data is accurate.
- Per-thread comment fetch failures are logged and skipped rather than failing the whole export.
- History is derived purely by enumerating blobs and their metadata, so no new table was needed.

## Validation

`dotnet build FeedbackFlow.slnx -c Release` succeeds with 0 errors and `dotnet test FeedbackFlow.slnx -c Release` passes (280 passed, 1 skipped). Updated the `FeedbackStorageClients` test helper for the new container; no new tests added per the project convention.