### PR TITLE
[feedbackflow] Add Moderator tier and let admins assign all non-Admin tiers

### DIFF
--- a/feedbackflow.tests/AccountTierUtilsTests.cs
+++ b/feedbackflow.tests/AccountTierUtilsTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedDump.Models.Account;
 using SharedDump.Utils.Account;
+using System.Linq;
 
 namespace FeedbackFlow.Tests;
 
@@ -15,6 +16,7 @@ public class AccountTierUtilsTests
         Assert.AreEqual("Pro", AccountTierUtils.GetTierName(AccountTier.Pro));
         Assert.AreEqual("Pro+", AccountTierUtils.GetTierName(AccountTier.ProPlus));
         Assert.AreEqual("Super User", AccountTierUtils.GetTierName(AccountTier.SuperUser));
+        Assert.AreEqual("Moderator", AccountTierUtils.GetTierName(AccountTier.Moderator));
         Assert.AreEqual("Admin", AccountTierUtils.GetTierName(AccountTier.Admin));
     }
 
@@ -44,6 +46,7 @@ public class AccountTierUtilsTests
         Assert.IsTrue(AccountTierUtils.SupportsEmailNotifications(AccountTier.Pro));
         Assert.IsTrue(AccountTierUtils.SupportsEmailNotifications(AccountTier.ProPlus));
         Assert.IsTrue(AccountTierUtils.SupportsEmailNotifications(AccountTier.SuperUser));
+        Assert.IsTrue(AccountTierUtils.SupportsEmailNotifications(AccountTier.Moderator));
         Assert.IsTrue(AccountTierUtils.SupportsEmailNotifications(AccountTier.Admin));
     }
 
@@ -73,7 +76,51 @@ public class AccountTierUtilsTests
         Assert.IsTrue(AccountTierUtils.SupportsTwitterAccess(AccountTier.Pro));
         Assert.IsTrue(AccountTierUtils.SupportsTwitterAccess(AccountTier.ProPlus));
         Assert.IsTrue(AccountTierUtils.SupportsTwitterAccess(AccountTier.SuperUser));
+        Assert.IsTrue(AccountTierUtils.SupportsTwitterAccess(AccountTier.Moderator));
         Assert.IsTrue(AccountTierUtils.SupportsTwitterAccess(AccountTier.Admin));
+    }
+
+    [TestMethod]
+    [TestCategory("Account")]
+    public void Moderator_ShouldHaveAdminPortalAccessButNotManagement()
+    {
+        Assert.IsTrue(AccountTierUtils.HasAdminPortalAccess(AccountTier.Moderator));
+        Assert.IsFalse(AccountTierUtils.IsAdmin(AccountTier.Moderator));
+        Assert.IsFalse(AccountTierUtils.CanManageUsers(AccountTier.Moderator));
+        Assert.IsFalse(AccountTierUtils.CanManageAdminReports(AccountTier.Moderator));
+    }
+
+    [TestMethod]
+    [TestCategory("Account")]
+    public void Admin_ShouldHaveFullAccess()
+    {
+        Assert.IsTrue(AccountTierUtils.IsAdmin(AccountTier.Admin));
+        Assert.IsTrue(AccountTierUtils.HasAdminPortalAccess(AccountTier.Admin));
+        Assert.IsTrue(AccountTierUtils.CanManageUsers(AccountTier.Admin));
+        Assert.IsTrue(AccountTierUtils.CanManageAdminReports(AccountTier.Admin));
+    }
+
+    [TestMethod]
+    [TestCategory("Account")]
+    public void NonInternalTiers_ShouldNotHaveAdminPortalAccess()
+    {
+        Assert.IsFalse(AccountTierUtils.HasAdminPortalAccess(AccountTier.Free));
+        Assert.IsFalse(AccountTierUtils.HasAdminPortalAccess(AccountTier.Pro));
+        Assert.IsFalse(AccountTierUtils.HasAdminPortalAccess(AccountTier.ProPlus));
+        Assert.IsFalse(AccountTierUtils.HasAdminPortalAccess(AccountTier.SuperUser));
+    }
+
+    [TestMethod]
+    [TestCategory("Account")]
+    public void GetAdminAssignableTiers_ShouldIncludeAllExceptAdmin()
+    {
+        var assignable = AccountTierUtils.GetAdminAssignableTiers();
+        Assert.IsFalse(assignable.Contains(AccountTier.Admin), "Admin must not be assignable");
+        Assert.IsTrue(assignable.Contains(AccountTier.Free));
+        Assert.IsTrue(assignable.Contains(AccountTier.Pro));
+        Assert.IsTrue(assignable.Contains(AccountTier.ProPlus));
+        Assert.IsTrue(assignable.Contains(AccountTier.SuperUser));
+        Assert.IsTrue(assignable.Contains(AccountTier.Moderator));
     }
 
     [TestMethod]

--- a/feedbackflow.tests/AdminUserTierFunctionsTests.cs
+++ b/feedbackflow.tests/AdminUserTierFunctionsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedDump.Models.Account;
+using SharedDump.Utils.Account;
 using System.Linq;
 
 namespace FeedbackFlow.Tests;
@@ -7,7 +8,7 @@ namespace FeedbackFlow.Tests;
 [TestClass]
 public class AdminUserTierFunctionsTests
 {
-    private static readonly AccountTier[] Allowed = new[] { AccountTier.Free, AccountTier.Pro, AccountTier.ProPlus };
+    private static readonly AccountTier[] Allowed = AccountTierUtils.GetAdminAssignableTiers().ToArray();
 
     [TestMethod]
     [TestCategory("Account")]
@@ -30,10 +31,20 @@ public class AdminUserTierFunctionsTests
 
     [TestMethod]
     [TestCategory("Account")]
+    public void AllowedTiers_IncludeInternalNonAdminTiers()
+    {
+        Assert.IsTrue(Allowed.Contains(AccountTier.Free));
+        Assert.IsTrue(Allowed.Contains(AccountTier.Pro));
+        Assert.IsTrue(Allowed.Contains(AccountTier.ProPlus));
+        Assert.IsTrue(Allowed.Contains(AccountTier.SuperUser));
+        Assert.IsTrue(Allowed.Contains(AccountTier.Moderator));
+    }
+
+    [TestMethod]
+    [TestCategory("Account")]
     public void DisallowedTiers_NotInAllowedSet()
     {
         Assert.IsFalse(Allowed.Contains(AccountTier.Admin));
-        Assert.IsFalse(Allowed.Contains(AccountTier.SuperUser));
     }
 
     [TestMethod]

--- a/feedbackfunctions/Account/AdminUserTierFunctions.cs
+++ b/feedbackfunctions/Account/AdminUserTierFunctions.cs
@@ -9,12 +9,13 @@ using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
 using FeedbackFunctions.Services.Authentication;
+using SharedDump.Utils.Account;
 
 namespace FeedbackFunctions.Account;
 
 /// <summary>
 /// Administrative functions for viewing and modifying user account tiers.
-/// Admins may set tiers only to Free, Pro, or ProPlus. No PII (email, name) is ever returned.
+/// Admins may set tiers to any tier except Admin (Free, Pro, Pro+, Super User, Moderator). No PII (email, name) is ever returned.
 /// Routes:
 /// - GET /api/GetAllUserTiersAdmin
 /// - POST /api/UpdateUserTierAdmin
@@ -27,11 +28,7 @@ public class AdminUserTierFunctions
     private readonly AuthenticationMiddleware _authMiddleware;
 
     private static readonly AccountTier[] AllowedTargetTiers =
-    [
-        AccountTier.Free,
-        AccountTier.Pro,
-        AccountTier.ProPlus
-    ];
+        AccountTierUtils.GetAdminAssignableTiers().ToArray();
 
     public AdminUserTierFunctions(
         ILogger<AdminUserTierFunctions> logger,
@@ -75,9 +72,9 @@ public class AdminUserTierFunctions
                 .GroupBy(u => u.UserId)
                 .ToDictionary(g => g.Key, g => g.First().Name ?? string.Empty);
 
-            // Project & mask (exclude admin & super users to avoid accidental edits + internal accounts)
+            // Project & mask (exclude only admin accounts to avoid accidental edits of administrators)
             var result = allAccounts
-                .Where(a => a.Tier != AccountTier.Admin && a.Tier != AccountTier.SuperUser)
+                .Where(a => a.Tier != AccountTier.Admin)
                 .Select(a => new UserTierAdminView
                 {
                     UserId = a.UserId, // full id (non-PII GUID) used for updates
@@ -162,7 +159,7 @@ public class AdminUserTierFunctions
                 return notFound;
             }
 
-            if (account.Tier == AccountTier.Admin || account.Tier == AccountTier.SuperUser)
+            if (account.Tier == AccountTier.Admin)
             {
                 var forbiddenTarget = req.CreateResponse(HttpStatusCode.Forbidden);
                 await forbiddenTarget.WriteAsJsonAsync(new { Data = (object?)null, Success = false, Message = "Cannot modify this account" });

--- a/feedbackfunctions/Admin/AdminDashboardFunctions.cs
+++ b/feedbackfunctions/Admin/AdminDashboardFunctions.cs
@@ -8,6 +8,7 @@ using FeedbackFunctions.Attributes;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Services.Account;
 using SharedDump.Models.Account;
+using SharedDump.Utils.Account;
 
 namespace FeedbackFunctions.Admin;
 
@@ -56,9 +57,9 @@ public class AdminDashboardFunctions
                 return unauthorizedResponse;
             }
 
-            // Check if user is admin
+            // Check if user has admin portal access (Admin or Moderator)
             var userAccount = await _userAccountService.GetUserAccountAsync(authenticatedUser.UserId);
-            if (userAccount?.Tier != AccountTier.Admin)
+            if (userAccount is null || !AccountTierUtils.HasAdminPortalAccess(userAccount.Tier))
             {
                 var forbiddenResponse = req.CreateResponse(HttpStatusCode.Forbidden);
                 await forbiddenResponse.WriteStringAsync("Admin access required");

--- a/feedbackfunctions/Reports/RedditExportFunctions.cs
+++ b/feedbackfunctions/Reports/RedditExportFunctions.cs
@@ -13,6 +13,7 @@ using SharedDump.Models.Account;
 using SharedDump.Models.Reddit;
 using SharedDump.Models.Reports;
 using SharedDump.Services.Interfaces;
+using SharedDump.Utils.Account;
 
 namespace FeedbackFunctions.Reports;
 
@@ -428,7 +429,7 @@ public class RedditExportFunctions
         }
 
         var userAccount = await _userAccountService.GetUserAccountAsync(authenticatedUser.UserId);
-        if (userAccount?.Tier != AccountTier.Admin)
+        if (userAccount is null || !AccountTierUtils.HasAdminPortalAccess(userAccount.Tier))
         {
             var forbidden = req.CreateResponse(HttpStatusCode.Forbidden);
             await forbidden.WriteStringAsync("Admin access required");

--- a/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
+++ b/feedbackfunctions/Reports/ReportDataAdminFunctions.cs
@@ -11,6 +11,7 @@ using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Reports;
 using SharedDump.Models.Account;
 using SharedDump.Models.Reports;
+using SharedDump.Utils.Account;
 
 namespace FeedbackFunctions.Reports;
 
@@ -194,7 +195,7 @@ public class ReportDataAdminFunctions
         }
 
         var userAccount = await _userAccountService.GetUserAccountAsync(authenticatedUser.UserId);
-        if (userAccount?.Tier != AccountTier.Admin)
+        if (userAccount is null || !AccountTierUtils.HasAdminPortalAccess(userAccount.Tier))
         {
             var forbidden = req.CreateResponse(HttpStatusCode.Forbidden);
             await forbidden.WriteStringAsync("Admin access required");

--- a/feedbackfunctions/Services/Account/UserAccountService.cs
+++ b/feedbackfunctions/Services/Account/UserAccountService.cs
@@ -296,6 +296,14 @@ public class UserAccountService : IUserAccountService
                 ApiLimit = 1000,
                 AnalysisRetentionDays = 3650 // 10 years
             },
+            AccountTier.Moderator => new AccountLimits 
+            { 
+                AnalysisLimit = 10000,
+                ReportLimit = 10000,
+                FeedQueryLimit = 10000,
+                ApiLimit = 1000,
+                AnalysisRetentionDays = 3650 // 10 years
+            },
             AccountTier.Admin => new AccountLimits 
             { 
                 AnalysisLimit = 10000,

--- a/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
+++ b/feedbackwebapp/Components/Admin/AdminFeaturesPanel.razor
@@ -15,27 +15,33 @@
                     <div class="desc">Metrics & usage</div>
                 </a>
             </div>
-            <div class="col-6 col-md-3">
-                <a href="/admin/api-keys" class="admin-feature-tile d-block text-decoration-none">
-                    <div class="icon-wrapper"><i class="bi bi-key"></i></div>
-                    <div class="title">API Keys</div>
-                    <div class="desc">User key mgmt</div>
-                </a>
-            </div>
-            <div class="col-6 col-md-3">
-                <a href="/admin/user-tiers" class="admin-feature-tile d-block text-decoration-none">
-                    <div class="icon-wrapper"><i class="bi bi-people"></i></div>
-                    <div class="title">User Tiers</div>
-                    <div class="desc">Plans & limits</div>
-                </a>
-            </div>
-            <div class="col-6 col-md-3">
-                <a href="/admin/reports" class="admin-feature-tile d-block text-decoration-none">
-                    <div class="icon-wrapper"><i class="bi bi-file-earmark-bar-graph"></i></div>
-                    <div class="title">Reports</div>
-                    <div class="desc">Automation</div>
-                </a>
-            </div>
+            @if (CanManageUsers)
+            {
+                <div class="col-6 col-md-3">
+                    <a href="/admin/api-keys" class="admin-feature-tile d-block text-decoration-none">
+                        <div class="icon-wrapper"><i class="bi bi-key"></i></div>
+                        <div class="title">API Keys</div>
+                        <div class="desc">User key mgmt</div>
+                    </a>
+                </div>
+                <div class="col-6 col-md-3">
+                    <a href="/admin/user-tiers" class="admin-feature-tile d-block text-decoration-none">
+                        <div class="icon-wrapper"><i class="bi bi-people"></i></div>
+                        <div class="title">User Tiers</div>
+                        <div class="desc">Plans & limits</div>
+                    </a>
+                </div>
+            }
+            @if (CanManageAdminReports)
+            {
+                <div class="col-6 col-md-3">
+                    <a href="/admin/reports" class="admin-feature-tile d-block text-decoration-none">
+                        <div class="icon-wrapper"><i class="bi bi-file-earmark-bar-graph"></i></div>
+                        <div class="title">Reports</div>
+                        <div class="desc">Automation</div>
+                    </a>
+                </div>
+            }
             <div class="col-6 col-md-3">
                 <a href="/admin/report-data" class="admin-feature-tile d-block text-decoration-none">
                     <div class="icon-wrapper"><i class="bi bi-database-down"></i></div>
@@ -53,3 +59,8 @@
         </div>
     </div>
 </div>
+
+@code {
+    [Parameter] public bool CanManageUsers { get; set; } = true;
+    [Parameter] public bool CanManageAdminReports { get; set; } = true;
+}

--- a/feedbackwebapp/Components/Admin/AdminUserTierManagement.razor
+++ b/feedbackwebapp/Components/Admin/AdminUserTierManagement.razor
@@ -1,6 +1,7 @@
 @namespace FeedbackWebApp.Components.Admin
 @using FeedbackWebApp.Services.Account
 @using SharedDump.Models.Account
+@using SharedDump.Utils.Account
 @inject IAdminUserTierService AdminUserTierService
 @inject IToastService ToastService
 
@@ -11,7 +12,7 @@
                 <i class="bi bi-people me-2"></i>
                 User Tier Management
             </h5>
-            <small class="text-muted">Modify user tiers (Free, Pro, Pro+). No personal data shown.</small>
+            <small class="text-muted">Modify user tiers (any tier except Admin). No personal data shown.</small>
         </div>
         <div class="admin-user-tiers-toolbar d-flex align-items-center gap-2">
             <div class="position-relative filter-input-wrapper">
@@ -76,9 +77,10 @@
                                 <td class="name-cell" title="@u.MaskedName">@u.MaskedName</td>
                                 <td>
                                     <select class="form-select form-select-sm" @bind="u.Tier" @bind:after="() => OnTierChanged(u)" disabled="@isProcessing">
-                                        <option value="@AccountTier.Free">Free</option>
-                                        <option value="@AccountTier.Pro">Pro</option>
-                                        <option value="@AccountTier.ProPlus">Pro+</option>
+                                        @foreach (var tier in AssignableTiers)
+                                        {
+                                            <option value="@tier">@AccountTierUtils.GetTierName(tier)</option>
+                                        }
                                     </select>
                                 </td>
                                 <td class="d-none d-md-table-cell">@u.AnalysesUsed</td>
@@ -149,6 +151,7 @@
 
 @code {
     private List<AdminUserTierInfo>? users;
+    private static readonly IReadOnlyList<AccountTier> AssignableTiers = AccountTierUtils.GetAdminAssignableTiers();
     private bool isLoading = true;
     private bool isProcessing = false;
     private string? processingUser;

--- a/feedbackwebapp/Components/Pages/AccountSettings.razor
+++ b/feedbackwebapp/Components/Pages/AccountSettings.razor
@@ -63,14 +63,14 @@
                                         </span>
                                     </div>
                                 }
-                                else if (userAccount?.Tier == AccountTier.Admin)
+                                else if (userAccount?.Tier == AccountTier.Moderator)
                                 {
                                     <div class="mt-2">
                                         <span class="badge bg-warning text-dark fs-6">
-                                            <i class="bi bi-star-fill me-1"></i>
-                                            Admin
+                                            <i class="bi bi-shield-fill me-1"></i>
+                                            Moderator
                                         </span>
-                                        <p class="text-muted small mt-1 mb-0">Administrative Account</p>
+                                        <p class="text-muted small mt-1 mb-0">Moderator Account</p>
                                     </div>
                                 }
                             </div>
@@ -91,6 +91,13 @@
                                             <span class="badge bg-warning text-dark ms-2">
                                                 <i class="bi bi-star-fill me-1"></i>
                                                 Admin
+                                            </span>
+                                        }
+                                        else if (userAccount?.Tier == AccountTier.Moderator)
+                                        {
+                                            <span class="badge bg-warning text-dark ms-2">
+                                                <i class="bi bi-shield-fill me-1"></i>
+                                                Moderator
                                             </span>
                                         }
                                     </p>

--- a/feedbackwebapp/Components/Pages/Admin/Admin.razor
+++ b/feedbackwebapp/Components/Pages/Admin/Admin.razor
@@ -4,6 +4,7 @@
 @using FeedbackWebApp.Services.Account
 @using SharedDump.Models.Account
 @using SharedDump.Utils
+@using SharedDump.Utils.Account
 @inject IAuthenticationService AuthService
 @inject IAccountServiceProvider AccountServiceProvider
 @inject IToastService ToastService
@@ -49,7 +50,7 @@
             <i class="bi bi-gear-fill"></i>
             Administration
         </h1>
-        <AdminFeaturesPanel />
+        <AdminFeaturesPanel CanManageUsers="canManageUsers" CanManageAdminReports="canManageAdminReports" />
     }
 </div>
 
@@ -57,6 +58,8 @@
     private bool isLoading = true;
     private bool isAuthenticated = false;
     private bool isAdmin = false;
+    private bool canManageUsers = false;
+    private bool canManageAdminReports = false;
     private string errorMessage = string.Empty;
     private bool _firstRenderProcessed = false;
 
@@ -116,7 +119,10 @@
             var accountResult = await accountService.GetUserAccountAndLimitsAsync();
             if (accountResult.HasValue)
             {
-                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+                var tier = accountResult.Value.account?.Tier;
+                isAdmin = tier.HasValue && AccountTierUtils.HasAdminPortalAccess(tier.Value);
+                canManageUsers = tier.HasValue && AccountTierUtils.CanManageUsers(tier.Value);
+                canManageAdminReports = tier.HasValue && AccountTierUtils.CanManageAdminReports(tier.Value);
             }
 
             if (!isAdmin && ToastService is not null)

--- a/feedbackwebapp/Components/Pages/Admin/AdminDashboard.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminDashboard.razor
@@ -6,6 +6,7 @@
 @using SharedDump.Models.Admin
 @using SharedDump.Models.Account
 @using SharedDump.Utils
+@using SharedDump.Utils.Account
 @inject IAdminDashboardService AdminDashboardService
 @inject IAccountServiceProvider AccountServiceProvider
 @inject IToastService ToastService
@@ -122,7 +123,7 @@
             var accountResult = await accountService.GetUserAccountAndLimitsAsync();
             if (accountResult.HasValue)
             {
-                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+                isAdmin = accountResult.Value.account?.Tier is { } dt && AccountTierUtils.HasAdminPortalAccess(dt);
             }
             if (isAdmin)
             {

--- a/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminRedditExport.razor
@@ -4,6 +4,7 @@
 @using FeedbackWebApp.Services.Account
 @using SharedDump.Models.Reports
 @using SharedDump.Models.Account
+@using SharedDump.Utils.Account
 @using Microsoft.JSInterop
 @inject FeedbackWebApp.Services.IRedditExportService RedditExportService
 @inject IAuthenticationService AuthService
@@ -327,7 +328,7 @@
             var accountResult = await accountService.GetUserAccountAndLimitsAsync();
             if (accountResult.HasValue)
             {
-                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+                isAdmin = accountResult.Value.account?.Tier is { } et && AccountTierUtils.HasAdminPortalAccess(et);
             }
 
             if (isAdmin)

--- a/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
+++ b/feedbackwebapp/Components/Pages/Admin/AdminReportData.razor
@@ -4,6 +4,7 @@
 @using FeedbackWebApp.Services.Account
 @using SharedDump.Models.Reports
 @using SharedDump.Models.Account
+@using SharedDump.Utils.Account
 @using Microsoft.JSInterop
 @inject FeedbackWebApp.Services.IReportDataAdminService ReportDataAdminService
 @inject IAuthenticationService AuthService
@@ -175,7 +176,7 @@
             var accountResult = await accountService.GetUserAccountAndLimitsAsync();
             if (accountResult.HasValue)
             {
-                isAdmin = accountResult.Value.account?.Tier == AccountTier.Admin;
+                isAdmin = accountResult.Value.account?.Tier is { } rt && AccountTierUtils.HasAdminPortalAccess(rt);
             }
 
             if (isAdmin)

--- a/shareddump/Models/Account/AccountTier.cs
+++ b/shareddump/Models/Account/AccountTier.cs
@@ -6,5 +6,6 @@ public enum AccountTier
     Pro = 1,
     ProPlus = 2,
     SuperUser = 100,
+    Moderator = 200,
     Admin = 225
 }

--- a/shareddump/Utils/Account/AccountTierUtils.cs
+++ b/shareddump/Utils/Account/AccountTierUtils.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using SharedDump.Models.Account;
 
 namespace SharedDump.Utils.Account
@@ -10,6 +13,7 @@ namespace SharedDump.Utils.Account
             AccountTier.Pro => "Pro",
             AccountTier.ProPlus => "Pro+",
             AccountTier.SuperUser => "Super User",
+            AccountTier.Moderator => "Moderator",
             AccountTier.Admin => "Admin",
             _ => "Unknown"
         };
@@ -20,6 +24,7 @@ namespace SharedDump.Utils.Account
             AccountTier.Pro => "Priority processing, email notifications, increased limits, X access, basic support.",
             AccountTier.ProPlus => "Pro features with highest limits.",
             AccountTier.SuperUser => "Internal account with unlimited access.",
+            AccountTier.Moderator => "Internal moderator account with admin tools, excluding user management and admin report setup.",
             AccountTier.Admin => "Internal administrative account with unlimited access.",
             _ => "Unknown tier."
         };
@@ -36,6 +41,7 @@ namespace SharedDump.Utils.Account
                 AccountTier.Pro => true,
                 AccountTier.ProPlus => true,
                 AccountTier.SuperUser => true,
+                AccountTier.Moderator => true,
                 AccountTier.Admin => true,
                 _ => false
             };
@@ -62,6 +68,7 @@ namespace SharedDump.Utils.Account
                 AccountTier.Pro => true,
                 AccountTier.ProPlus => true,
                 AccountTier.SuperUser => true,
+                AccountTier.Moderator => true,
                 AccountTier.Admin => true,
                 _ => false
             };
@@ -87,6 +94,7 @@ namespace SharedDump.Utils.Account
             {
                 AccountTier.ProPlus => true,
                 AccountTier.SuperUser => true,
+                AccountTier.Moderator => true,
                 AccountTier.Admin => true,
                 _ => false
             };
@@ -100,5 +108,36 @@ namespace SharedDump.Utils.Account
         {
             return AccountTier.ProPlus;
         }
+
+        /// <summary>
+        /// Determines whether the tier is a full administrator.
+        /// </summary>
+        public static bool IsAdmin(AccountTier tier) => tier == AccountTier.Admin;
+
+        /// <summary>
+        /// Determines whether the tier can access the admin portal and its shared tools
+        /// (dashboard, report data, reddit export). Includes Admin and Moderator.
+        /// </summary>
+        public static bool HasAdminPortalAccess(AccountTier tier)
+            => tier is AccountTier.Admin or AccountTier.Moderator;
+
+        /// <summary>
+        /// Determines whether the tier can manage other users (user tiers and API keys).
+        /// Admin only.
+        /// </summary>
+        public static bool CanManageUsers(AccountTier tier) => tier == AccountTier.Admin;
+
+        /// <summary>
+        /// Determines whether the tier can set up and manage admin reports. Admin only.
+        /// </summary>
+        public static bool CanManageAdminReports(AccountTier tier) => tier == AccountTier.Admin;
+
+        /// <summary>
+        /// Gets the set of tiers an admin is allowed to assign to a user (everything except Admin).
+        /// </summary>
+        public static IReadOnlyList<AccountTier> GetAdminAssignableTiers()
+            => Enum.GetValues<AccountTier>()
+                .Where(t => t != AccountTier.Admin)
+                .ToArray();
     }
 }


### PR DESCRIPTION
## Why

We needed an internal role that can help operate the admin surface (metrics, report data, exports) without granting the sensitive capabilities of a full Admin, namely managing other users and configuring automated admin reports. This PR adds a **Moderator** tier for that purpose. It also removes an artificial limitation where admins could only assign Free/Pro/Pro+ tiers.

## What changed

**New `Moderator` tier** (`AccountTier.Moderator = 200`, internal-only, unlimited limits like SuperUser/Admin). A Moderator behaves like an Admin except it **cannot manage users** (User Tiers + API Keys) and **cannot set up admin reports**.

Access decisions are centralized in `AccountTierUtils` rather than scattered `Tier == Admin` checks:
- `HasAdminPortalAccess` (Admin + Moderator) gates the admin landing, Dashboard, Report Data, and Reddit Export.
- `CanManageUsers` / `CanManageAdminReports` (Admin only) gate User Tiers, API Keys, and Reports config.
- `GetAdminAssignableTiers` returns every tier except Admin.

**Admins can now assign any tier except Admin.** `AdminUserTierFunctions` accepts all non-Admin tiers, lists all non-Admin accounts (so SuperUser/Moderator accounts are now visible and downgradable), and only blocks edits to Admin accounts. The User Tiers dropdown renders the assignable set dynamically.

**Web UI:** `AdminFeaturesPanel` hides the User Tiers / API Keys / Reports tiles for Moderators; the three shared pages use `HasAdminPortalAccess`; the User Tiers / API Keys / Reports pages stay Admin-only. Added a Moderator badge in Account Settings.

## Notes for reviewers

- Backend authorization is enforced independently of the UI. Moderators are blocked at the function level for the Admin-only endpoints, so hiding the tiles is defense-in-depth, not the only gate.
- Enum value `200` keeps ordering SuperUser(100) < Moderator(200) < Admin(225); JSON serialization is unaffected and no data migration is required (`Tier` is an existing property).
- The `AdminWeeklyReport` email recipient selection and the report processor/config endpoints intentionally remain Admin-only.
- Minor: the `tier-moderator` badge CSS class in `UsageDashboard` isn't defined, so a Moderator's usage badge falls back to default styling. Easy to add a dedicated style if desired.

Build passes and all 285 tests pass (`dotnet test FeedbackFlow.slnx -c Release`).