### PR TITLE
[feedbackflow] Add developer shareable report API

### DIFF
--- a/FeedbackFlow.MCP.Shared/FeedbackFlowToolsShared.cs
+++ b/FeedbackFlow.MCP.Shared/FeedbackFlowToolsShared.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace FeedbackFlow.MCP.Shared;
@@ -21,6 +23,17 @@ public sealed class FeedbackFlowToolsShared
         AnalysisOnly = 0,
         CommentsOnly = 1,
         AnalysisAndComments = 2
+    }
+
+    private sealed class DeveloperReportRequest
+    {
+        public List<string> Urls { get; set; } = new();
+
+        public string? CustomPrompt { get; set; }
+
+        public bool SaveReport { get; set; }
+
+        public bool IsPublic { get; set; } = true;
     }
 
     [McpServerTool, Description("Analyze feedback from various sources using AI (AutoAnalyze function).")]
@@ -60,6 +73,59 @@ public sealed class FeedbackFlowToolsShared
             {
                 return $"Error: API call failed with status {response.StatusCode}. Response: {content}";
             }
+        }
+        catch (Exception ex)
+        {
+            return $"Error: Exception occurred - {ex.Message}";
+        }
+    }
+
+    [McpServerTool, Description("Generate a combined AI analysis report from one or more feedback URLs, optionally save it publicly, and return the report URL.")]
+    public async Task<string> GenerateDeveloperReport(
+        [Description("The URLs to analyze and combine into a single report. Supported platforms include GitHub, YouTube, Reddit, DevBlogs, Twitter/X, BlueSky, and Hacker News.")] List<string> urls,
+        [Description("Custom analysis prompt (optional)")] string? customPrompt = null,
+        [Description("Save the generated report and return a web URL (default: true)")] bool saveReport = true,
+        [Description("Make the saved report publicly accessible (default: true)")] bool isPublic = true)
+    {
+        var apiKey = _authenticationProvider.GetAuthenticationToken();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return _authenticationProvider.GetAuthenticationErrorMessage();
+        }
+
+        if (urls == null || urls.Count == 0 || urls.All(string.IsNullOrWhiteSpace))
+        {
+            return "Error: At least one URL is required.";
+        }
+
+        try
+        {
+            using var httpClient = _httpClientFactory.CreateClient();
+
+            var requestBody = new DeveloperReportRequest
+            {
+                Urls = urls.Where(url => !string.IsNullOrWhiteSpace(url)).Select(url => url.Trim()).ToList(),
+                CustomPrompt = customPrompt,
+                SaveReport = saveReport,
+                IsPublic = isPublic
+            };
+
+            var requestUrl = $"{BaseUrl}/api/GenerateDeveloperReport";
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("x-api-key", apiKey);
+
+            var response = await httpClient.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                return content;
+            }
+
+            return $"Error: API call failed with status {response.StatusCode}. Response: {content}";
         }
         catch (Exception ex)
         {

--- a/feedbackflow.tests/WebUrlHelperTests.cs
+++ b/feedbackflow.tests/WebUrlHelperTests.cs
@@ -131,6 +131,25 @@ public class WebUrlHelperTests
     }
 
     [TestMethod]
+    public void BuildAnalysisUrl_WithAnalysisId_ReturnsCorrectUrl()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WebUrl"] = "https://test.com/"
+            })
+            .Build();
+        var analysisId = Guid.NewGuid().ToString();
+
+        // Act
+        var result = WebUrlHelper.BuildAnalysisUrl(configuration, analysisId);
+
+        // Assert
+        Assert.AreEqual($"https://test.com/analysis/{analysisId}", result);
+    }
+
+    [TestMethod]
     public void BuildReportQueryUrl_WithReportId_ReturnsCorrectUrl()
     {
         // Arrange

--- a/feedbackfunctions/FeedbackAnalysis/DeveloperReportModels.cs
+++ b/feedbackfunctions/FeedbackAnalysis/DeveloperReportModels.cs
@@ -1,0 +1,38 @@
+namespace FeedbackFunctions.FeedbackAnalysis;
+
+public class DeveloperReportRequest
+{
+    public List<string> Urls { get; set; } = new();
+
+    public string? CustomPrompt { get; set; }
+
+    public bool SaveReport { get; set; }
+
+    public bool IsPublic { get; set; } = true;
+}
+
+public class DeveloperReportSourceResult
+{
+    public string Url { get; set; } = string.Empty;
+
+    public string SourceType { get; set; } = string.Empty;
+
+    public bool HasComments { get; set; }
+}
+
+public class DeveloperReportResponse
+{
+    public string Analysis { get; set; } = string.Empty;
+
+    public string SourceType { get; set; } = string.Empty;
+
+    public List<string> Urls { get; set; } = new();
+
+    public List<DeveloperReportSourceResult> Sources { get; set; } = new();
+
+    public string? SavedAnalysisId { get; set; }
+
+    public string? Url { get; set; }
+
+    public bool IsPublic { get; set; }
+}

--- a/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
+++ b/feedbackfunctions/FeedbackAnalysis/FeedbackFunctions.cs
@@ -23,10 +23,12 @@ using SharedDump.Services.Interfaces;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
+using FeedbackFunctions.Services.Sharing;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Twitter;
 using FeedbackFunctions.Utils;
 using SharedDump.Models.Account;
+using SharedDump.Utils;
 
 namespace FeedbackFunctions.FeedbackAnalysis;
 
@@ -52,6 +54,8 @@ public class FeedbackFunctions
     private readonly IUserAccountService _userAccountService;
     private readonly ITwitterThreadCacheService _twitterThreadCacheService;
     private readonly IFeatureGateService _featureGateService;
+    private readonly ISharedAnalysisStorageService _sharedAnalysisStorageService;
+    private readonly IConfiguration _configuration;
 
     /// <summary>
     /// Initializes a new instance of the FeedbackFunctions class
@@ -78,7 +82,9 @@ public class FeedbackFunctions
         AuthenticationMiddleware authMiddleware,
         IUserAccountService userAccountService,
         ITwitterThreadCacheService twitterThreadCacheService,
-        IFeatureGateService featureGateService)
+        IFeatureGateService featureGateService,
+        ISharedAnalysisStorageService sharedAnalysisStorageService,
+        IConfiguration configuration)
     {
         _logger = logger;
         _githubService = githubService;
@@ -93,6 +99,8 @@ public class FeedbackFunctions
         _userAccountService = userAccountService;
         _twitterThreadCacheService = twitterThreadCacheService;
         _featureGateService = featureGateService;
+        _sharedAnalysisStorageService = sharedAnalysisStorageService;
+        _configuration = configuration;
     }
 
     /// <summary>
@@ -836,8 +844,8 @@ public class FeedbackFunctions
 
             var queryParams = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
             var url = queryParams["url"];
-        var customPrompt = queryParams["customPrompt"];
-        var typeStr = queryParams["type"];
+            var customPrompt = queryParams["customPrompt"];
+            var typeStr = queryParams["type"];
 
             if (string.IsNullOrEmpty(url))
             {
@@ -846,16 +854,238 @@ public class FeedbackFunctions
                 return response;
             }
 
-        var responseType = int.TryParse(typeStr, out var type) ? type : 0;
+            var responseType = int.TryParse(typeStr, out var type) ? type : 0;
+            var analysisSource = await AnalyzeUrlSourceAsync(url);
 
-            string serviceType;
-            object platformData;
-            string commentsText;
-
-            // Determine platform and get data
-            if (SharedDump.Utils.UrlParsing.IsGitHubUrl(url))
+            // Handle different response types
+            HttpResponseData successResponse;
+            switch (responseType)
             {
-                serviceType = "github";
+                case 1: // Comments only
+                    if (string.IsNullOrEmpty(analysisSource.CommentsText))
+                    {
+                        successResponse = req.CreateResponse(HttpStatusCode.OK);
+                        await successResponse.WriteAsJsonAsync(new { message = "No comments available for this URL" });
+                    }
+                    else
+                    {
+                        successResponse = req.CreateResponse(HttpStatusCode.OK);
+                        await successResponse.WriteAsJsonAsync(new { comments = analysisSource.CommentsText });
+                    }
+                    break;
+
+                case 2: // Both comments and analysis
+                    if (string.IsNullOrEmpty(analysisSource.CommentsText))
+                    {
+                        successResponse = req.CreateResponse(HttpStatusCode.OK);
+                        await successResponse.WriteAsJsonAsync(new
+                        {
+                            comments = "No comments available",
+                            analysis = "## No Comments Available\n\nThere are no comments to analyze at this time."
+                        });
+                    }
+                    else
+                    {
+                        var analysis = await GenerateAnalysisAsync(
+                            analysisSource.ServiceType,
+                            analysisSource.CommentsText,
+                            customPrompt);
+
+                        successResponse = req.CreateResponse(HttpStatusCode.OK);
+                        await successResponse.WriteAsJsonAsync(new
+                        {
+                            comments = analysisSource.CommentsText,
+                            analysis
+                        });
+                    }
+                    break;
+
+                default: // 0 or any other value = Analysis only (default behavior)
+                    successResponse = req.CreateResponse(HttpStatusCode.OK);
+                    if (string.IsNullOrEmpty(analysisSource.CommentsText))
+                    {
+                        await successResponse.WriteStringAsync("## No Comments Available\n\nThere are no comments to analyze at this time.");
+                    }
+                    else
+                    {
+                        var analysis = await GenerateAnalysisAsync(
+                            analysisSource.ServiceType,
+                            analysisSource.CommentsText,
+                            customPrompt);
+                        await successResponse.WriteStringAsync(analysis);
+                    }
+                    break;
+            }
+                 
+            // Track API usage on successful completion (AutoAnalyze = 1 usage point)
+            await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 1, _userAccountService, _logger, url);
+                 
+            return successResponse;
+        }
+        catch (FeatureDisabledException ex)
+        {
+            var response = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+            await response.WriteAsJsonAsync(new
+            {
+                ex.ErrorCode,
+                ex.Message
+            });
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing auto-analyze request");
+            var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await response.WriteStringAsync("An error occurred processing the request");
+            return response;
+        }
+    }
+
+    [Function("GenerateDeveloperReport")]
+    public async Task<HttpResponseData> GenerateDeveloperReport(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    {
+        try
+        {
+            _logger.LogInformation("Processing developer report generation request");
+
+            var request = await JsonSerializer.DeserializeAsync(
+                req.Body,
+                FeedbackJsonContext.Default.DeveloperReportRequest);
+            var urls = request?.Urls
+                .Where(url => !string.IsNullOrWhiteSpace(url))
+                .Select(url => url.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList() ?? new List<string>();
+
+            if (urls.Count == 0)
+            {
+                var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+                await badResponse.WriteStringAsync("At least one URL is required.");
+                return badResponse;
+            }
+
+            var (isValid, errorResponse, userId) = await ApiKeyValidationHelper.ValidateApiKeyWithUsageAsync(
+                req,
+                req.FunctionContext.InstanceServices.GetRequiredService<IApiKeyService>(),
+                _userAccountService,
+                _logger,
+                urls.Count);
+            if (!isValid)
+            {
+                return errorResponse!;
+            }
+
+            var sources = new List<UrlAnalysisSource>();
+            foreach (var url in urls)
+            {
+                sources.Add(await AnalyzeUrlSourceAsync(url));
+            }
+
+            var combinedComments = BuildCombinedCommentsText(sources);
+            var sourceType = string.Join(", ", sources.Select(source => source.SourceType).Distinct(StringComparer.OrdinalIgnoreCase));
+            var hasAnyComments = sources.Any(source => !string.IsNullOrWhiteSpace(source.CommentsText));
+            var analysis = !hasAnyComments
+                ? "## No Comments Available\n\nThere are no comments to analyze at this time."
+                : await GenerateAnalysisAsync(sourceType, combinedComments, request?.CustomPrompt);
+
+            string? savedAnalysisId = null;
+            string? publicUrl = null;
+            var shouldSave = request?.SaveReport == true;
+            var isPublic = request?.IsPublic ?? true;
+            if (shouldSave)
+            {
+                var analysisData = new AnalysisData
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Title = $"{sourceType} Analysis",
+                    Summary = AnalysisDataHelper.TruncateSummary(analysis) ?? string.Empty,
+                    FullAnalysis = analysis,
+                    SourceType = sourceType,
+                    UserInput = AnalysisDataHelper.TruncateUserInput(string.Join(", ", urls)),
+                    CreatedDate = DateTime.UtcNow,
+                };
+
+                savedAnalysisId = await _sharedAnalysisStorageService.SaveAnalysisAsync(userId!, analysisData, isPublic);
+                publicUrl = WebUrlHelper.BuildAnalysisUrl(_configuration, savedAnalysisId);
+            }
+
+            await ApiKeyValidationHelper.TrackApiUsageAsync(
+                userId!,
+                urls.Count,
+                _userAccountService,
+                _logger,
+                string.Join(", ", urls));
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(new DeveloperReportResponse
+            {
+                Analysis = analysis,
+                SourceType = sourceType,
+                Urls = urls,
+                Sources = sources.Select(source => new DeveloperReportSourceResult
+                {
+                    Url = source.Url,
+                    SourceType = source.SourceType,
+                    HasComments = !string.IsNullOrWhiteSpace(source.CommentsText)
+                }).ToList(),
+                SavedAnalysisId = savedAnalysisId,
+                Url = publicUrl,
+                IsPublic = shouldSave && isPublic
+            });
+
+            return response;
+        }
+        catch (FeatureDisabledException ex)
+        {
+            var response = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+            await response.WriteAsJsonAsync(new
+            {
+                ex.ErrorCode,
+                ex.Message
+            });
+            return response;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Invalid developer report request");
+            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            await response.WriteStringAsync(ex.Message);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing developer report generation request");
+            var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+            await response.WriteStringAsync("An error occurred processing the request");
+            return response;
+        }
+    }
+
+    #region Helper Methods for AutoAnalyze
+
+    private sealed record UrlAnalysisSource(string Url, string ServiceType, string SourceType, string CommentsText);
+
+    private sealed class FeatureDisabledException : Exception
+    {
+        public FeatureDisabledException(string errorCode, string message)
+            : base(message)
+        {
+            ErrorCode = errorCode;
+        }
+
+        public string ErrorCode { get; }
+    }
+
+    private async Task<UrlAnalysisSource> AnalyzeUrlSourceAsync(string url)
+    {
+        string serviceType;
+        object platformData;
+        string commentsText;
+
+        if (SharedDump.Utils.UrlParsing.IsGitHubUrl(url))
+        {
+            serviceType = "github";
             platformData = await GetGitHubDataForAnalysis(url);
             commentsText = ConvertGitHubDataToCommentsText(platformData);
         }
@@ -869,9 +1099,7 @@ public class FeedbackFunctions
         {
             if (SharedDump.Utils.UrlParsing.IsRedditShareUrl(url))
             {
-                var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
-                await badResponse.WriteStringAsync(SharedDump.Utils.UrlParsing.UnsupportedRedditShareUrlMessage);
-                return badResponse;
+                throw new InvalidOperationException(SharedDump.Utils.UrlParsing.UnsupportedRedditShareUrlMessage);
             }
 
             serviceType = "reddit";
@@ -886,17 +1114,11 @@ public class FeedbackFunctions
         }
         else if (SharedDump.Utils.UrlParsing.IsTwitterUrl(url))
         {
-            // Check if X/Twitter is enabled
             if (!_featureGateService.IsXEnabled)
             {
-                var disabledResponse = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
-                await disabledResponse.WriteAsJsonAsync(new
-                {
-                    ErrorCode = "X_FEATURE_DISABLED",
-                    Message = "X/Twitter integration is currently disabled."
-                });
-                return disabledResponse;
+                throw new FeatureDisabledException("X_FEATURE_DISABLED", "X/Twitter integration is currently disabled.");
             }
+
             serviceType = "twitter";
             platformData = await GetTwitterDataForAnalysis(url);
             commentsText = ConvertTwitterDataToCommentsText(platformData);
@@ -913,104 +1135,73 @@ public class FeedbackFunctions
             var hackerNewsId = SharedDump.Utils.UrlParsing.ExtractHackerNewsId(url);
             if (string.IsNullOrEmpty(hackerNewsId))
             {
-                var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
-                await badResponse.WriteStringAsync("Could not extract Hacker News ID from URL");
-                return badResponse;
+                throw new InvalidOperationException("Could not extract Hacker News ID from URL");
             }
-                platformData = await GetHackerNewsDataForAnalysis(hackerNewsId);
-                commentsText = ConvertHackerNewsDataToCommentsText(platformData);
-            }
-                else
-                {
-                    var response = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await response.WriteStringAsync("Unsupported URL format. Supported platforms: GitHub, YouTube, Reddit, DevBlogs, Twitter/X, BlueSky, Hacker News");
-                    return response;
-                }
 
-                // Handle different response types
-                HttpResponseData successResponse;
-                
-                switch (responseType)
-                {
-                    case 1: // Comments only
-                        if (string.IsNullOrEmpty(commentsText))
-                        {
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteAsJsonAsync(new { message = "No comments available for this URL" });
-                        }
-                        else
-                        {
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteAsJsonAsync(new { comments = commentsText });
-                        }
-                        break;
-                        
-                    case 2: // Both comments and analysis
-                        if (string.IsNullOrEmpty(commentsText))
-                        {
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteAsJsonAsync(new { 
-                                comments = "No comments available",
-                                analysis = "## No Comments Available\n\nThere are no comments to analyze at this time."
-                            });
-                        }
-                        else
-                        {
-                            var analysisBuilder = new System.Text.StringBuilder();
-                            await foreach (var update in _analyzerService.GetStreamingAnalysisAsync(
-                                serviceType, 
-                                commentsText,
-                                customPrompt))
-                            {
-                                analysisBuilder.Append(update);
-                            }
-                            
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteAsJsonAsync(new { 
-                                comments = commentsText,
-                                analysis = analysisBuilder.ToString()
-                            });
-                        }
-                        break;
-                        
-                    default: // 0 or any other value = Analysis only (default behavior)
-                        if (string.IsNullOrEmpty(commentsText))
-                        {
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteStringAsync("## No Comments Available\n\nThere are no comments to analyze at this time.");
-                        }
-                        else
-                        {
-                            var analysisBuilder = new System.Text.StringBuilder();
-                            await foreach (var update in _analyzerService.GetStreamingAnalysisAsync(
-                                serviceType, 
-                                commentsText,
-                                customPrompt))
-                            {
-                                analysisBuilder.Append(update);
-                            }
-                            
-                            successResponse = req.CreateResponse(HttpStatusCode.OK);
-                            await successResponse.WriteStringAsync(analysisBuilder.ToString());
-                        }
-                        break;
-                }
-                
-                // Track API usage on successful completion (AutoAnalyze = 1 usage point)
-                await ApiKeyValidationHelper.TrackApiUsageAsync(userId!, 1, _userAccountService, _logger, url);
-                
-                return successResponse;
+            platformData = await GetHackerNewsDataForAnalysis(hackerNewsId);
+            commentsText = ConvertHackerNewsDataToCommentsText(platformData);
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogError(ex, "Error processing auto-analyze request");
-            var response = req.CreateResponse(HttpStatusCode.InternalServerError);
-            await response.WriteStringAsync("An error occurred processing the request");
-            return response;
+            throw new InvalidOperationException("Unsupported URL format. Supported platforms: GitHub, YouTube, Reddit, DevBlogs, Twitter/X, BlueSky, Hacker News");
         }
+
+        return new UrlAnalysisSource(url, serviceType, GetDisplaySourceType(serviceType), commentsText);
     }
 
-    #region Helper Methods for AutoAnalyze
+    private static string GetDisplaySourceType(string serviceType)
+    {
+        return serviceType.ToLowerInvariant() switch
+        {
+            "github" => "GitHub",
+            "youtube" => "YouTube",
+            "reddit" => "Reddit",
+            "devblogs" => "DevBlogs",
+            "twitter" => "Twitter",
+            "bluesky" => "BlueSky",
+            "hackernews" => "HackerNews",
+            _ => serviceType
+        };
+    }
+
+    private async Task<string> GenerateAnalysisAsync(string serviceType, string commentsText, string? customPrompt)
+    {
+        var analysisBuilder = new System.Text.StringBuilder();
+        await foreach (var update in _analyzerService.GetStreamingAnalysisAsync(
+            serviceType,
+            commentsText,
+            customPrompt))
+        {
+            analysisBuilder.Append(update);
+        }
+
+        return analysisBuilder.ToString();
+    }
+
+    private static string BuildCombinedCommentsText(IEnumerable<UrlAnalysisSource> sources)
+    {
+        var result = new System.Text.StringBuilder();
+        foreach (var source in sources)
+        {
+            result.AppendLine($"# Source: {source.SourceType}");
+            result.AppendLine($"URL: {source.Url}");
+            result.AppendLine();
+
+            if (string.IsNullOrWhiteSpace(source.CommentsText))
+            {
+                result.AppendLine("No comments available for this URL.");
+            }
+            else
+            {
+                result.AppendLine(source.CommentsText);
+            }
+
+            result.AppendLine();
+            result.AppendLine("---");
+        }
+
+        return result.ToString();
+    }
 
     private async Task<object> GetGitHubDataForAnalysis(string url)
     {

--- a/feedbackfunctions/FeedbackJsonContext.cs
+++ b/feedbackfunctions/FeedbackJsonContext.cs
@@ -5,6 +5,7 @@ using SharedDump.Models.YouTube;
 using SharedDump.Models.Reddit;
 using SharedDump.Models.ContentSearch;
 using SharedDump.Models.Reports;
+using FeedbackFunctions.FeedbackAnalysis;
 
 namespace FeedbackFunctions;
 
@@ -24,4 +25,9 @@ namespace FeedbackFunctions;
 [JsonSerializable(typeof(OmniSearchResponse))]
 [JsonSerializable(typeof(OmniSearchResult))]
 [JsonSerializable(typeof(List<OmniSearchResult>))]
+[JsonSerializable(typeof(DeveloperReportRequest))]
+[JsonSerializable(typeof(DeveloperReportResponse))]
+[JsonSerializable(typeof(DeveloperReportSourceResult))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(List<DeveloperReportSourceResult>))]
 public partial class FeedbackJsonContext : JsonSerializerContext { }

--- a/feedbackfunctions/Program.cs
+++ b/feedbackfunctions/Program.cs
@@ -20,6 +20,7 @@ using FeedbackFunctions.Services.Authentication;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Services.Account;
 using FeedbackFunctions.Services.Email;
+using FeedbackFunctions.Services.Sharing;
 using FeedbackFunctions.Services.Storage;
 using FeedbackFunctions.Services.Twitter;
 using System.Configuration;
@@ -268,6 +269,7 @@ void RegisterStorageServices(IServiceCollection services)
     services.AddSingleton<FeedbackStorageClients>();
     services.AddSingleton<ITableInitializationService, TableInitializationService>();
     services.AddSingleton<IReportStorageService, ReportStorageService>();
+    services.AddSingleton<ISharedAnalysisStorageService, SharedAnalysisStorageService>();
     services.AddScoped<IFeatureGateService, FeatureGateService>();
 }
 

--- a/feedbackfunctions/Services/Sharing/ISharedAnalysisStorageService.cs
+++ b/feedbackfunctions/Services/Sharing/ISharedAnalysisStorageService.cs
@@ -1,0 +1,14 @@
+using SharedDump.Models;
+
+namespace FeedbackFunctions.Services.Sharing;
+
+public interface ISharedAnalysisStorageService
+{
+    bool TryGetCachedAnalysis(string id, out string analysisJson);
+
+    void CacheAnalysis(string id, string analysisJson);
+
+    Task<string> SaveAnalysisAsync(string userId, AnalysisData analysisData, bool isPublic);
+
+    void RemoveCachedAnalysis(string id);
+}

--- a/feedbackfunctions/Services/Sharing/SharedAnalysisStorageService.cs
+++ b/feedbackfunctions/Services/Sharing/SharedAnalysisStorageService.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+
+using FeedbackFunctions.Services.Storage;
+using Microsoft.Extensions.Logging;
+using SharedDump.Models;
+
+namespace FeedbackFunctions.Services.Sharing;
+
+public class SharedAnalysisStorageService : ISharedAnalysisStorageService
+{
+    private readonly FeedbackStorageClients _storage;
+    private readonly ITableInitializationService _tableInitializationService;
+    private readonly ILogger<SharedAnalysisStorageService> _logger;
+    private readonly ConcurrentDictionary<string, string> _sharedAnalysisCache = new();
+
+    public SharedAnalysisStorageService(
+        FeedbackStorageClients storage,
+        ITableInitializationService tableInitializationService,
+        ILogger<SharedAnalysisStorageService> logger)
+    {
+        _storage = storage;
+        _tableInitializationService = tableInitializationService;
+        _logger = logger;
+    }
+
+    public bool TryGetCachedAnalysis(string id, out string analysisJson)
+    {
+        return _sharedAnalysisCache.TryGetValue(id, out analysisJson!);
+    }
+
+    public void CacheAnalysis(string id, string analysisJson)
+    {
+        _sharedAnalysisCache[id] = analysisJson;
+    }
+
+    public async Task<string> SaveAnalysisAsync(string userId, AnalysisData analysisData, bool isPublic)
+    {
+        await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
+
+        var id = Guid.NewGuid().ToString();
+        var analysisJson = JsonSerializer.Serialize(
+            analysisData,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var blobClient = _storage.SharedAnalysesContainer.GetBlobClient($"{id}.json");
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(analysisJson));
+        await blobClient.UploadAsync(ms, overwrite: true);
+
+        var sharedAnalysisEntity = new SharedAnalysisEntity(userId, id, analysisData, isPublic);
+        await _storage.SharedAnalysesTable.UpsertEntityAsync(sharedAnalysisEntity);
+
+        _sharedAnalysisCache[id] = analysisJson;
+
+        _logger.LogInformation(
+            "Successfully saved shared analysis {Id} for user {UserId} (Public: {IsPublic})",
+            id,
+            userId,
+            isPublic);
+
+        return id;
+    }
+
+    public void RemoveCachedAnalysis(string id)
+    {
+        _sharedAnalysisCache.TryRemove(id, out _);
+    }
+}

--- a/feedbackfunctions/Sharing/SharingFunctions.cs
+++ b/feedbackfunctions/Sharing/SharingFunctions.cs
@@ -1,16 +1,14 @@
 using System.Net;
 using Azure.Storage.Blobs;
-using Azure.Data.Tables;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SharedDump.Models;
-using System.Text;
 using System.Text.Json;
 using FeedbackFunctions.Middleware;
 using FeedbackFunctions.Extensions;
 using FeedbackFunctions.Attributes;
+using FeedbackFunctions.Services.Sharing;
 using FeedbackFunctions.Services.Storage;
 
 namespace FeedbackFunctions;
@@ -56,12 +54,11 @@ public class SharingFunctions
 {
     private readonly FeedbackFunctions.Services.Account.IUserAccountService _userAccountService;
     private const string ContainerName = "shared-analyses";
-    private const string TableName = "SharedAnalyses";
     private readonly ILogger<SharingFunctions> _logger;
     private readonly AuthenticationMiddleware _authMiddleware;
     private readonly FeedbackStorageClients _storage;
     private readonly ITableInitializationService _tableInitializationService;
-    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _sharedAnalysisCache = new();
+    private readonly ISharedAnalysisStorageService _sharedAnalysisStorageService;
 
     /// <summary>
     /// Initializes a new instance of the SharingFunctions class
@@ -74,12 +71,14 @@ public class SharingFunctions
         AuthenticationMiddleware authMiddleware,
         FeedbackStorageClients storage,
         ITableInitializationService tableInitializationService,
+        ISharedAnalysisStorageService sharedAnalysisStorageService,
         FeedbackFunctions.Services.Account.IUserAccountService userAccountService)
     {
         _logger = logger;
         _authMiddleware = authMiddleware;
         _storage = storage;
         _tableInitializationService = tableInitializationService;
+        _sharedAnalysisStorageService = sharedAnalysisStorageService;
         _userAccountService = userAccountService;
     }
 
@@ -88,7 +87,6 @@ public class SharingFunctions
     /// Saves an analysis to Azure Blob Storage for sharing
     /// </summary>
     /// <param name="req">HTTP request containing the analysis data</param>
-    /// <param name="containerClient">Azure Blob container client injected by the runtime</param>
     /// <returns>HTTP response with the unique ID for accessing the shared analysis</returns>
     /// <remarks>
     /// The request body should contain a JSON representation of an AnalysisData object.
@@ -109,8 +107,7 @@ public class SharingFunctions
     [Function("SaveSharedAnalysis")]
     [Authorize]
     public async Task<HttpResponseData> SaveSharedAnalysis(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
-        [BlobInput(ContainerName, Connection = "ProductionStorage")] BlobContainerClient containerClient)
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
         _logger.LogInformation("Processing shared analysis save request");
         
@@ -142,29 +139,9 @@ public class SharingFunctions
         var analysisData = requestData.Analysis;
         var isPublic = requestData.IsPublic;
         
-        // Generate unique ID
-        string id = Guid.NewGuid().ToString();
-        
         try
         {
-            await _tableInitializationService.EnsureSharedAnalysesStorageAsync();
-
-            // Save to blob storage with the ID as the blob name
-            var blobClient = containerClient.GetBlobClient($"{id}.json");
-            
-            // Store the original analysis data (not the request wrapper)
-            var analysisJson = JsonSerializer.Serialize(analysisData, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(analysisJson));
-            await blobClient.UploadAsync(ms, overwrite: true);
-
-            // Save metadata to table storage with public flag
-            var sharedAnalysisEntity = new SharedAnalysisEntity(user.UserId, id, analysisData, isPublic);
-            await _storage.SharedAnalysesTable.UpsertEntityAsync(sharedAnalysisEntity);
-
-            // Add to in-memory cache
-            _sharedAnalysisCache[id] = analysisJson;
-
-            _logger.LogInformation("Successfully saved shared analysis {Id} for user {UserId} (Public: {IsPublic})", id, user.UserId, isPublic);
+            var id = await _sharedAnalysisStorageService.SaveAnalysisAsync(user.UserId, analysisData, isPublic);
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "application/json");
@@ -283,7 +260,7 @@ public class SharingFunctions
         _logger.LogDebug("Access granted for analysis {Id}", id);
 
         // Check in-memory cache first
-        if (_sharedAnalysisCache.TryGetValue(id, out var cachedJson))
+        if (_sharedAnalysisStorageService.TryGetCachedAnalysis(id, out var cachedJson))
         {
             var cachedResponse = req.CreateResponse(HttpStatusCode.OK);
             cachedResponse.Headers.Add("Content-Type", "application/json");
@@ -292,7 +269,7 @@ public class SharingFunctions
         }
 
         // Add to cache for future requests
-        _sharedAnalysisCache[id] = analysisJson;
+        _sharedAnalysisStorageService.CacheAnalysis(id, analysisJson);
 
         var response = req.CreateResponse(HttpStatusCode.OK);
         response.Headers.Add("Content-Type", "application/json");
@@ -378,7 +355,7 @@ public class SharingFunctions
             await _storage.SharedAnalysesTable.UpsertEntityAsync(entity);
 
             // Remove from cache to ensure fresh data is loaded with updated visibility settings
-            _sharedAnalysisCache.TryRemove(id, out _);
+            _sharedAnalysisStorageService.RemoveCachedAnalysis(id);
             _logger.LogDebug("Removed analysis {Id} from cache after visibility update", id);
 
             _logger.LogInformation("Successfully updated analysis {Id} visibility to {IsPublic} for user {UserId}", 
@@ -468,7 +445,7 @@ public class SharingFunctions
                 await blobClient.DeleteIfExistsAsync();
 
                 // Remove from cache if present
-                _sharedAnalysisCache.TryRemove(id, out _);
+                _sharedAnalysisStorageService.RemoveCachedAnalysis(id);
 
                 deletedBlobCount++;
             }
@@ -631,7 +608,7 @@ public class SharingFunctions
             await blobClient.DeleteIfExistsAsync();
 
             // Remove from in-memory cache if present
-            _sharedAnalysisCache.TryRemove(id, out _);
+            _sharedAnalysisStorageService.RemoveCachedAnalysis(id);
 
             _logger.LogInformation("Successfully deleted shared analysis {Id} for user {UserId}", id, user.UserId);
 

--- a/feedbackfunctions/Utils/WebUrlHelper.cs
+++ b/feedbackfunctions/Utils/WebUrlHelper.cs
@@ -57,7 +57,18 @@ public static class WebUrlHelper
         
         return url;
     }
-    
+
+    /// <summary>
+    /// Builds a URL for viewing a shared analysis by ID
+    /// </summary>
+    /// <param name="configuration">The configuration service</param>
+    /// <param name="analysisId">The shared analysis ID</param>
+    /// <returns>The complete URL to view the shared analysis</returns>
+    public static string BuildAnalysisUrl(IConfiguration configuration, string analysisId)
+    {
+        return BuildUrl(configuration, $"/analysis/{analysisId}");
+    }
+     
     /// <summary>
     /// Builds a URL for viewing a report with query parameters
     /// </summary>


### PR DESCRIPTION
Developers using the API and MCP server can analyze feedback URLs, but they did not have a way to generate the same saved, shareable report URL that the website creates. This adds that workflow so API and MCP callers can submit multiple URLs, generate one combined report, optionally save it publicly, and receive the web URL for the saved analysis.

## Summary

- Added `GenerateDeveloperReport` for multi-URL developer report generation with optional public save.
- Extracted shared-analysis persistence into `ISharedAnalysisStorageService` so website saves and developer API saves use the same blob/table storage path.
- Refactored `AutoAnalyze` internals to reuse URL detection, comment fetching, and analysis generation without changing existing response behavior.
- Added an MCP `GenerateDeveloperReport` tool that posts to the new API and returns the JSON response including the saved report URL.
- Added `WebUrlHelper.BuildAnalysisUrl()` with test coverage for public analysis URLs.

## Validation

- `dotnet build FeedbackFlow.slnx --configuration Release`
- `dotnet test FeedbackFlow.slnx --configuration Release`